### PR TITLE
[Feat/#8] 여행 일정 추가 - 국가/도시 구현

### DIFF
--- a/backend/truvel/build.gradle
+++ b/backend/truvel/build.gradle
@@ -35,10 +35,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation("io.github.cdimascio:java-dotenv:5.2.2")
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.mysql:mysql-connector-j:8.2.0'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/backend/truvel/build.gradle
+++ b/backend/truvel/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation("io.github.cdimascio:java-dotenv:5.2.2")
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j:8.2.0'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlan.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlan.java
@@ -29,6 +29,10 @@ public class TravelPlan {
     @Column(nullable = false)
     private String city;
 
-
+    //--엔티티 관련 메서드--//
+    public void updateDates(LocalDate startDate, LocalDate endDate) {
+        this.start_date = startDate;
+        this.end_date = endDate;
+    }
 
 }

--- a/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlan.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlan.java
@@ -1,0 +1,34 @@
+package alt_t.truvel.travelPlan;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@Table(name="TravelPlan")
+public class TravelPlan {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable=false)
+    private String nation;
+
+//    @Column(nullable = false)
+    private LocalDate start_date;
+
+//    @Column(nullable = false)
+    private LocalDate end_date;
+
+    @Column(nullable = false)
+    private String city;
+
+
+
+}

--- a/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanController.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanController.java
@@ -1,9 +1,12 @@
 package alt_t.truvel.travelPlan;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -18,5 +21,11 @@ public class TravelPlanController {
     public ResponseEntity<TravelPlanDraftResponse> createTravelPlanDraft(@RequestBody TravelPlanDraftRequest request) {
         TravelPlanDraftResponse response = travelPlanService.createTravelPlanDraft(request);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @PatchMapping("/travels/draft/{travel_plan_id}/date")
+    public ResponseEntity<TravelPlanDataResponse> updateTravelPlanDate(@PathVariable("travel_plan_id") Long travelPlanId, @RequestBody @Valid TravelPlanDateRequest request) {
+        TravelPlanDataResponse response = travelPlanService.saveTravelPlanDate(travelPlanId, request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanController.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanController.java
@@ -1,0 +1,22 @@
+package alt_t.truvel.travelPlan;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@RequiredArgsConstructor // 생성자 주입
+@Controller
+public class TravelPlanController {
+
+    private final TravelPlanRepository travelPlanRepository;
+    private final TravelPlanService travelPlanService;
+
+    @PostMapping("/travels/draft")
+    public ResponseEntity<TravelPlanDraftResponse> createTravelPlanDraft(@RequestBody TravelPlanDraftRequest request) {
+        TravelPlanDraftResponse response = travelPlanService.createTravelPlanDraft(request);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+}

--- a/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanDataResponse.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanDataResponse.java
@@ -1,0 +1,11 @@
+package alt_t.truvel.travelPlan;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TravelPlanDataResponse {
+    private String message;
+    private Long travel_plan_id;
+}

--- a/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanDateRequest.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanDateRequest.java
@@ -1,0 +1,23 @@
+package alt_t.truvel.travelPlan;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.LocalDate;
+
+@Getter
+public class TravelPlanDateRequest {
+
+    @NotNull
+    private LocalDate start_date;
+
+    @NotNull
+    private LocalDate end_date;
+
+    @Builder
+    public TravelPlanDateRequest(LocalDate start_date, LocalDate end_date) {
+        this.start_date = start_date;
+        this.end_date = end_date;
+    }
+}

--- a/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanDraftRequest.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanDraftRequest.java
@@ -1,0 +1,26 @@
+package alt_t.truvel.travelPlan;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+// 여행 기본 정보 입력 - 여행지 입력의 요청 DTO
+public class TravelPlanDraftRequest {
+    @NotBlank
+    private String nation;
+
+    @NotBlank
+    private String city;
+
+    @Builder
+    public TravelPlanDraftRequest(String nation, String city) {
+        this.city = city;
+        this.nation = nation;
+    }
+
+
+    public TravelPlan toTravelPlanDraft() {
+        return new TravelPlan(null, nation, null, null, city);
+    }
+}

--- a/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanDraftResponse.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanDraftResponse.java
@@ -1,0 +1,15 @@
+package alt_t.truvel.travelPlan;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Getter
+public class TravelPlanDraftResponse {
+
+    private String message;
+
+    private Long travel_plan_id;
+}

--- a/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanRepository.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanRepository.java
@@ -1,0 +1,6 @@
+package alt_t.truvel.travelPlan;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TravelPlanRepository extends JpaRepository<TravelPlan, Long> {
+}

--- a/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanService.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanService.java
@@ -1,0 +1,23 @@
+package alt_t.truvel.travelPlan;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TravelPlanService {
+
+    private final TravelPlanRepository travelPlanRepository;
+
+    public TravelPlanDraftResponse createTravelPlanDraft(TravelPlanDraftRequest request) {
+
+         // TravelPlan 엔티티 생성 - request 객체의 변환 메소드 활용
+        TravelPlan travelPlanDraft = request.toTravelPlanDraft();
+    
+        TravelPlan savedTravelPlan = travelPlanRepository.save(travelPlanDraft);
+
+        return new TravelPlanDraftResponse("여행 초안 생성 완료", savedTravelPlan.getId()); // 응답 DTO 반환
+
+    }
+
+}

--- a/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanService.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanService.java
@@ -3,6 +3,8 @@ package alt_t.truvel.travelPlan;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.NoSuchElementException;
+
 @Service
 @RequiredArgsConstructor
 public class TravelPlanService {
@@ -18,6 +20,19 @@ public class TravelPlanService {
 
         return new TravelPlanDraftResponse("여행 초안 생성 완료", savedTravelPlan.getId()); // 응답 DTO 반환
 
+    }
+
+    public TravelPlanDataResponse saveTravelPlanDate(Long travelPlanId, TravelPlanDateRequest request) {
+        // 기존 여행 계획 조회
+        TravelPlan travelPlan = travelPlanRepository.findById(travelPlanId)
+                .orElseThrow(() -> new NoSuchElementException("해당 여행 계획페이지가 없습니다."));
+
+        // 날짜 업데이트
+        travelPlan.updateDates(request.getStart_date(), request.getEnd_date());
+
+        TravelPlan savedTravelPlan = travelPlanRepository.save(travelPlan);
+
+        return new TravelPlanDataResponse("여행 날짜 저장 완료", savedTravelPlan.getId());
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
feat/#8 

## 📝작업 내용
1. build.gradle에서 spring validation 의존성 추가
2. TravelPlan Entity 정의
3. TravelPlan의 서비스, 컨트롤러, 레포지토리 구현
4. 여행 일정 추가 - 국가/도시 기능 구현

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
<img width="371" alt="image" src="https://github.com/user-attachments/assets/c75fd77a-4528-4807-a8f1-8531ae943ff2" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 기능 구현후 노션에 정리후 공유드리겠습니다!
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
