### PR TITLE
[Feat/#10] 여행 일정 추가 - 날짜 기능 구현

### DIFF
--- a/backend/truvel/build.gradle
+++ b/backend/truvel/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation("io.github.cdimascio:java-dotenv:5.2.2")
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j:8.2.0'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlan.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlan.java
@@ -29,6 +29,10 @@ public class TravelPlan {
     @Column(nullable = false)
     private String city;
 
-
+    //--엔티티 관련 메서드--//
+    public void updateDates(LocalDate startDate, LocalDate endDate) {
+        this.start_date = startDate;
+        this.end_date = endDate;
+    }
 
 }

--- a/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanController.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanController.java
@@ -1,9 +1,12 @@
 package alt_t.truvel.travelPlan;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -18,5 +21,11 @@ public class TravelPlanController {
     public ResponseEntity<TravelPlanDraftResponse> createTravelPlanDraft(@RequestBody TravelPlanDraftRequest request) {
         TravelPlanDraftResponse response = travelPlanService.createTravelPlanDraft(request);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @PatchMapping("/travels/draft/{travel_plan_id}/date")
+    public ResponseEntity<TravelPlanDataResponse> updateTravelPlanDate(@PathVariable("travel_plan_id") Long travelPlanId, @RequestBody @Valid TravelPlanDateRequest request) {
+        TravelPlanDataResponse response = travelPlanService.saveTravelPlanDate(travelPlanId, request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanDataResponse.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanDataResponse.java
@@ -1,0 +1,11 @@
+package alt_t.truvel.travelPlan;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TravelPlanDataResponse {
+    private String message;
+    private Long travel_plan_id;
+}

--- a/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanDateRequest.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanDateRequest.java
@@ -1,0 +1,23 @@
+package alt_t.truvel.travelPlan;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.LocalDate;
+
+@Getter
+public class TravelPlanDateRequest {
+
+    @NotNull
+    private LocalDate start_date;
+
+    @NotNull
+    private LocalDate end_date;
+
+    @Builder
+    public TravelPlanDateRequest(LocalDate start_date, LocalDate end_date) {
+        this.start_date = start_date;
+        this.end_date = end_date;
+    }
+}

--- a/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanService.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/travelPlan/TravelPlanService.java
@@ -3,6 +3,8 @@ package alt_t.truvel.travelPlan;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.NoSuchElementException;
+
 @Service
 @RequiredArgsConstructor
 public class TravelPlanService {
@@ -18,6 +20,19 @@ public class TravelPlanService {
 
         return new TravelPlanDraftResponse("여행 초안 생성 완료", savedTravelPlan.getId()); // 응답 DTO 반환
 
+    }
+
+    public TravelPlanDataResponse saveTravelPlanDate(Long travelPlanId, TravelPlanDateRequest request) {
+        // 기존 여행 계획 조회
+        TravelPlan travelPlan = travelPlanRepository.findById(travelPlanId)
+                .orElseThrow(() -> new NoSuchElementException("해당 여행 계획페이지가 없습니다."));
+
+        // 날짜 업데이트
+        travelPlan.updateDates(request.getStart_date(), request.getEnd_date());
+
+        TravelPlan savedTravelPlan = travelPlanRepository.save(travelPlan);
+
+        return new TravelPlanDataResponse("여행 날짜 저장 완료", savedTravelPlan.getId());
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#10 

## 📝작업 내용
1. TravelPlanDateRequest/Response 정의
2. 그에 따라서 서비스, 컨트롤러 수정
3. 여행 일정 추가 기능 구현

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
<img width="371" alt="image" src="https://github.com/user-attachments/assets/44a50fc7-2967-418e-94a1-462865839462" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
