### PR TITLE
[Feat] Editor 엔티티 정의 및 친구검색 / 여행계획에 친구추가 / 여행계획에서 초대받은 친구들 목록 조회 기능 구현

### DIFF
--- a/backend/truvel/src/main/java/alt_t/truvel/auth/emailVerification/domain/entity/EmailVerification.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/auth/emailVerification/domain/entity/EmailVerification.java
@@ -3,14 +3,15 @@ package alt_t.truvel.auth.emailVerification.domain.entity;
 
 import alt_t.truvel.auth.user.domain.entity.User;
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Builder
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class EmailVerification {
 
     @Id

--- a/backend/truvel/src/main/java/alt_t/truvel/auth/user/domain/entity/User.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/auth/user/domain/entity/User.java
@@ -1,6 +1,7 @@
 package alt_t.truvel.auth.user.domain.entity;
 
 import alt_t.truvel.auth.emailVerification.domain.entity.EmailVerification;
+import alt_t.truvel.editor.domain.entity.Editor;
 import alt_t.truvel.travelPlan.domain.entity.TravelPlan;
 import jakarta.persistence.*;
 import lombok.*;
@@ -27,7 +28,7 @@ public class User {
     @Column
     private String password;
 
-    @Column
+    @Column(unique = true)
     private String nickname;
 
     @Column
@@ -57,6 +58,7 @@ public class User {
     @Builder.Default
     private Boolean emailVerified = false; // 이메일 인증 여부, 기본값으로 false 설정
 
+    @Builder.Default
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<EmailVerification> emailVerifications = new ArrayList<>();
 
@@ -64,6 +66,10 @@ public class User {
     @Builder.Default
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TravelPlan> travelPlans = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Editor> editors = new ArrayList<>();
 
     public void setTravelPlan(TravelPlan travelPlan) {
     }
@@ -80,6 +86,11 @@ public class User {
 
     public void setEmailVerified(boolean emailVerified) {
         this.emailVerified = emailVerified;
+    }
+
+    public void addEditor(Editor editor) {
+        this.editors.add(editor);
+        editor.setUser(this);
     }
 
 

--- a/backend/truvel/src/main/java/alt_t/truvel/auth/user/domain/repository/UserRepository.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/auth/user/domain/repository/UserRepository.java
@@ -3,6 +3,7 @@ package alt_t.truvel.auth.user.domain.repository;
 import alt_t.truvel.auth.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -14,5 +15,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
      * @return : 해당 이메일을 사용하는 사용자의 정보
      */
     Optional<User> findByEmail(String email);
+
+    /**
+     * 닉네임으로 사용자 검색 (대소문자 구분 없이 부분 일치)
+     * @param nickname : 검색할 닉네임
+     * @return : 검색된 사용자 목록
+     */
+    Optional<User> findByNicknameContainingIgnoreCase(String nickname);
 
 }

--- a/backend/truvel/src/main/java/alt_t/truvel/editor/controller/EditorController.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/editor/controller/EditorController.java
@@ -1,0 +1,122 @@
+package alt_t.truvel.editor.controller;
+
+import alt_t.truvel.auth.security.UserPrincipal;
+import alt_t.truvel.editor.dto.*;
+import java.util.List;
+import alt_t.truvel.editor.service.EditorService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class EditorController {
+
+    private final EditorService editorService;
+
+    // ========== 사용자 검색 ==========
+    
+    /**
+     * 사용자 검색 (닉네임으로 검색) - 친구검색
+     * @param nickname 검색할 닉네임 (쿼리 파라미터)
+     * @return 검색된 사용자 목록
+     */
+    @GetMapping("/editors")
+    public ResponseEntity<EditorSearchResponse> searchUsers(
+            @RequestParam String nickname) {
+        EditorSearchResponse response = editorService.searchUsersByNickname(nickname);
+        return ResponseEntity.ok(response);
+    }
+
+
+
+    // ========== 여행 계획 편집자 ==========
+
+    /**
+     * 특정 여행 계획의 편집자 목록 조회 - 상태 구분 없이 전체 반환
+     * @param travelPlanId 여행 계획 ID
+     * @return 편집자 목록
+     */
+    @GetMapping("/travels/{travelPlanId}/editors")
+    public ResponseEntity<List<EditorSearchResponse>> getTravelPlanEditors(
+            @PathVariable Long travelPlanId) {
+        List<EditorSearchResponse> editors = editorService.getEditors(travelPlanId);
+        return ResponseEntity.ok(editors);
+    }
+
+
+    /**
+     * 여행 계획에 편집자 추가 - 친구등록
+     * @param travelPlanId 여행 계획 ID
+     * @param request 초대할 사용자 정보
+     * @return 초대 결과
+     */
+    @PostMapping("/travels/{travelPlanId}/editors")
+    public ResponseEntity<EditorAddResponse> inviteEditor(
+            @PathVariable Long travelPlanId,
+            @RequestBody EditorAddRequest request,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        EditorAddResponse response = editorService.addEditorToTravelPlan(
+                travelPlanId, 
+                request.getEditorUserId(),
+                userPrincipal.getId()
+        );
+        return ResponseEntity.ok(response);
+    }
+
+
+
+    // ========== 초대 관련 ==========
+
+    /**
+     * 사용자가 받은 초대 목록 조회
+     * @param userId 사용자 ID
+     * @param status 초대 상태 (선택적, 기본값: PENDING)
+     * @return 초대 목록
+     */
+    // @GetMapping("/users/{userId}/invitations")
+    // public ResponseEntity<List<EditorSearchResponse>> getUserInvitations(
+    //         @PathVariable Long userId,
+    //         @RequestParam(defaultValue = "PENDING") String status) {
+    //     List<EditorSearchResponse> invitations = editorService.getUserInvitations(userId, status);
+    //     return ResponseEntity.ok(invitations);
+    // }
+
+    /**
+     * 여행계획 초대 수락
+     * @param editorId 편집자(Editor) id, 초대받은 사용자의 아이디
+     * @param userPrincipal 인증된 사용자 정보, 요청을 보내는 사용자의 정보를 담는 객체
+     * Note. editorId와 userId 둘 다 쓰는 이유는 초대받은 사람과 요청을 보내는 사람이 동일 사용자인지 판단하기 위함이다.
+     * @return 수락 결과
+     */
+    @PutMapping("/editors/{editorId}/accept")
+    public ResponseEntity<EditorAddResponse> acceptInvitation(
+            @PathVariable Long editorId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        EditorAddResponse response = editorService.acceptInvitation(
+                editorId,
+                userPrincipal.getId()
+        );
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 여행계획 초대 거절
+     * @param editorId 편집자(Editor) id, 초대받은 사용자의 아이디
+     * @param userPrincipal 인증된 사용자 정보, 요청을 보내는 사용자의 정보를 담는 객체
+     * Note. editorId와 userId 둘 다 쓰는 이유는 초대받은 사람과 요청을 보내는 사람이 동일 사용자인지 판단하기 위함이다.
+     * @return 거절 결과
+     */
+    @PutMapping("/editors/{editorId}/reject")
+    public ResponseEntity<EditorAddResponse> rejectInvitation(
+            @PathVariable Long editorId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+
+        EditorAddResponse response = editorService.rejectInvitation(
+                editorId,
+                userPrincipal.getId()
+        );
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/truvel/src/main/java/alt_t/truvel/editor/domain/entity/Editor.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/editor/domain/entity/Editor.java
@@ -1,0 +1,86 @@
+package alt_t.truvel.editor.domain.entity;
+
+import alt_t.truvel.auth.user.domain.entity.User;
+import alt_t.truvel.editor.enums.EditorRole;
+import alt_t.truvel.editor.enums.InvitationStatus;
+import alt_t.truvel.travelPlan.domain.entity.TravelPlan;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "editor", 
+       uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "travel_plan_id"}))
+public class Editor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "travel_plan_id", nullable = false)
+    private TravelPlan travelPlan;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private EditorRole role = EditorRole.EDITOR; // Editor 역할 -> 일행초대 페이지에서 EDITOR 역할의 사용자만 목록에 불러오도록 사용
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private InvitationStatus status = InvitationStatus.PENDING; // 초대수락 여부
+
+    // 연관관계 편의 메서드
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public void setTravelPlan(TravelPlan travelPlan) {
+        this.travelPlan = travelPlan;
+    }
+
+    // 초대 상태 관련 메서드
+
+    // 초대를 수락하는 메서드
+    public void acceptInvitation() {
+        this.status = InvitationStatus.ACCEPTED;
+    }
+
+
+    // 초대를 거절하는 메서드
+    public void rejectInvitation() {
+        this.status = InvitationStatus.REJECTED;
+    }
+
+
+    // 초대가 보류 상태인지 확인하는 메서드
+    public boolean isPending() {
+        return this.status == InvitationStatus.PENDING;
+    }
+
+
+    // 초대를 허락했는지 확인하는 메서드
+    public boolean isAccepted() {
+        return this.status == InvitationStatus.ACCEPTED;
+    }
+
+
+    // 초대를 거절했는지 확인하는 메서드
+    public boolean isRejected() {
+        return this.status == InvitationStatus.REJECTED;
+    }
+}

--- a/backend/truvel/src/main/java/alt_t/truvel/editor/domain/repository/EditorRepository.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/editor/domain/repository/EditorRepository.java
@@ -1,0 +1,49 @@
+package alt_t.truvel.editor.domain.repository;
+
+import alt_t.truvel.editor.domain.entity.Editor;
+import alt_t.truvel.auth.user.domain.entity.User;
+import alt_t.truvel.editor.enums.EditorRole;
+import alt_t.truvel.editor.enums.InvitationStatus;
+import alt_t.truvel.travelPlan.domain.entity.TravelPlan;
+import org.springframework.data.jpa.repository.JpaRepository;
+//import org.springframework.data.jpa.repository.Query;
+//import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface EditorRepository extends JpaRepository<Editor, Long> {
+
+    // 여행 계획의 모든 편집자를 조회하는 메서드
+    List<Editor> findByTravelPlan(TravelPlan travelPlan);
+
+    // 사용자가 편집자로 참여한 모든 여행 계획을 조회하는 메서드
+    List<Editor> findByUser(User user);
+
+    // 특정 사용자가 특정 여행 계획의 편집자인지 확인
+    Optional<Editor> findByUserAndTravelPlan(User user, TravelPlan travelPlan);
+
+    // 중복 추가 방지를 위한 존재 여부 확인 메서드
+    boolean existsByUserAndTravelPlan(User user, TravelPlan travelPlan);
+
+    // 특정 여행 계획의 편집자 수 조회
+//    @Query("SELECT COUNT(e) FROM Editor e WHERE e.travelPlan = :travelPlan")
+//    long countByTravelPlan(@Param("travelPlan") TravelPlan travelPlan);
+
+    // 특정 사용자의 역할별 편집자 권한을 조회하는 메서드
+    List<Editor> findByUserAndRole(User user, EditorRole role);
+
+    // 사용자별로 초대 상태를 조회하는 메서드
+    List<Editor> findByUserAndStatus(User user, InvitationStatus status);
+    
+    // 여행 계획에서 편집자의 초대 상태를 조회하는 메서드
+    List<Editor> findByTravelPlanAndStatus(TravelPlan travelPlan, InvitationStatus status);
+
+    // 여행 계획에서 사용자의 초대 수락여부를 생성일자 순서로 목록을 조회하는 메서드
+    List<Editor> findByUserAndStatusOrderByCreatedAtDesc(User user, InvitationStatus status);
+
+    // 여행 계획의 수락된 편집자만 조회
+    List<Editor> findByTravelPlanAndStatusAndRole(TravelPlan travelPlan, InvitationStatus status, EditorRole role);
+}

--- a/backend/truvel/src/main/java/alt_t/truvel/editor/dto/EditorAddRequest.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/editor/dto/EditorAddRequest.java
@@ -1,0 +1,21 @@
+package alt_t.truvel.editor.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EditorAddRequest { // 여행계획에 편집자를 추가할때 요청 DTO
+
+    // @NotNull
+    // private Long travelPlanId;
+
+    @NotNull
+    private Long editorUserId; // 편집자로서 초대할 사용자의 id
+
+    // @NotNull
+    // private Long currentUserId; // 현재 요청을 보낸 사용자의 id
+}

--- a/backend/truvel/src/main/java/alt_t/truvel/editor/dto/EditorAddResponse.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/editor/dto/EditorAddResponse.java
@@ -1,0 +1,30 @@
+package alt_t.truvel.editor.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.AllArgsConstructor;
+
+@Getter
+//@Builder
+//@AllArgsConstructor
+public class EditorAddResponse { // 편집자 추가, 초대 수락/거절 기능에 사용
+
+    @NotNull
+    private String message;
+
+    @NotNull
+    private Long editorId;
+
+//    @NotNull
+//    private String editorNickname;
+
+
+    @Builder
+    public EditorAddResponse(String message, Long editorId) {
+        this.message = message;
+        this.editorId = editorId;
+//        this.editorNickname = editorNickname;
+    }
+
+}

--- a/backend/truvel/src/main/java/alt_t/truvel/editor/dto/EditorSearchResponse.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/editor/dto/EditorSearchResponse.java
@@ -1,0 +1,27 @@
+package alt_t.truvel.editor.dto;
+
+import alt_t.truvel.editor.enums.InvitationStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+// @JsonInclude(JsonInclude.Include.NON_NULL)
+public class EditorSearchResponse {
+
+    @NotNull
+    private Long userId;
+
+    @NotNull
+    private String nickname;
+
+    private String profileImg;
+
+    @NotNull
+    private String email;
+
+    // 초대 수락 여부 (PENDING, ACCEPTED, REJECTED). 사용자 검색 응답에서는 null일 수 있음
+    private InvitationStatus status;
+}

--- a/backend/truvel/src/main/java/alt_t/truvel/editor/dto/InvitationResponse.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/editor/dto/InvitationResponse.java
@@ -1,0 +1,14 @@
+package alt_t.truvel.editor.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.AllArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class InvitationResponse {
+    private Long editorId;
+    private String status; // PENDING, ACCEPTED, REJECTED
+    private String message;
+}

--- a/backend/truvel/src/main/java/alt_t/truvel/editor/enums/EditorRole.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/editor/enums/EditorRole.java
@@ -1,0 +1,6 @@
+package alt_t.truvel.editor.enums;
+
+public enum EditorRole {
+    OWNER,   // 여행 계획을 생성한 사람
+    EDITOR   // 초대받은 편집자(친구)
+}

--- a/backend/truvel/src/main/java/alt_t/truvel/editor/enums/InvitationStatus.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/editor/enums/InvitationStatus.java
@@ -1,0 +1,7 @@
+package alt_t.truvel.editor.enums;
+
+public enum InvitationStatus {
+    PENDING,   // 초대 대기중
+    ACCEPTED,  // 수락됨
+    REJECTED   // 거절됨
+}

--- a/backend/truvel/src/main/java/alt_t/truvel/editor/service/EditorService.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/editor/service/EditorService.java
@@ -1,0 +1,293 @@
+package alt_t.truvel.editor.service;
+
+import alt_t.truvel.auth.user.domain.entity.User;
+import alt_t.truvel.auth.user.domain.repository.UserRepository;
+import alt_t.truvel.editor.domain.entity.Editor;
+import alt_t.truvel.editor.domain.repository.EditorRepository;
+import alt_t.truvel.editor.dto.EditorAddResponse;
+import alt_t.truvel.editor.dto.EditorSearchResponse;
+import alt_t.truvel.editor.enums.EditorRole;
+import alt_t.truvel.editor.enums.InvitationStatus;
+import alt_t.truvel.travelPlan.domain.entity.TravelPlan;
+import alt_t.truvel.travelPlan.domain.repository.TravelPlanRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EditorService {
+
+    private final UserRepository userRepository;
+    private final TravelPlanRepository travelPlanRepository;
+    private final EditorRepository editorRepository;
+
+
+    /**
+     * 사용자를 검색하는 메서드
+     * @param nickname : 검색하려는 사용자의 닉네임
+     * @return : 검색된 사용자 1명
+     */
+    public EditorSearchResponse searchUsersByNickname(String nickname) {
+        Optional<User> editor = userRepository.findByNicknameContainingIgnoreCase(nickname);
+
+        // Optional에 값이 있다면, 있다면 해당 사용자 정보로 반환
+        return editor.map(user -> EditorSearchResponse.builder()
+                        .userId(user.getId())
+                        .nickname(user.getNickname())
+                        .profileImg(user.getProfileImg())
+                        .email(user.getEmail())
+                        .build())
+                // 없다면, null 반환
+                .orElse(null);
+    }
+
+
+    /**
+     * 다른 사용자를 여행계획 편집자로 추가하는 메서드
+     * @param travelPlanId : 여행계획 아이디
+     * @param editorUserId : 추가하려는 편집자의 아이디
+     * @param currentUserId : 현재 요청을 보내는 사용자의 아이디, 권한 확인후 중복 추가를 방지하기 위해 사용함
+     * @return :
+     */
+    @Transactional
+    public EditorAddResponse addEditorToTravelPlan(Long travelPlanId, Long editorUserId, Long currentUserId) {
+        // 여행 계획 조회
+        TravelPlan travelPlan = travelPlanRepository.findById(travelPlanId)
+                .orElseThrow(() -> new IllegalArgumentException("여행 계획을 찾을 수 없습니다."));
+
+        // 추가할 편집자가 존재하는지 확인
+        User editorUser = userRepository.findById(editorUserId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // 요청을 보낸 사용자가 존재하는지 확인
+        User currentUser = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new IllegalArgumentException("현재 사용자를 찾을 수 없습니다."));
+
+        // 요청을 보낸 사용자의 권한 확인, 해당 여행계획에서 권한이 있는지 확인
+        boolean hasPermission = editorRepository.findByUserAndTravelPlan(currentUser, travelPlan).isPresent()
+                || travelPlan.getUser().getId().equals(currentUserId);
+
+        // 권한이 없다면, 메시지 반환
+        if (!hasPermission) {
+            return EditorAddResponse.builder()
+                    .message("여행 계획에 친구를 추가할 권한이 없습니다.")
+                    .build();
+        }
+
+        // 이미 편집자로 추가되어 있는지 확인
+        if (editorRepository.existsByUserAndTravelPlan(editorUser, travelPlan)) {
+            return EditorAddResponse.builder()
+                    .message("이미 해당 여행 계획의 편집자입니다.")
+                    .build();
+        }
+
+        // 자신을 추가하려는 경우 방지
+        if (editorUserId.equals(currentUserId)) {
+            return EditorAddResponse.builder()
+                    .message("자기 자신을 편집자로 추가할 수 없습니다.")
+                    .build();
+        }
+
+        // Editor 엔티티 생성
+        Editor editor = Editor.builder()
+                .user(editorUser) // 연관관계 매핑 (editor : user = N:1)
+                .travelPlan(travelPlan) // 연관관계 매핑 (editor : TravelPlan = N:1)
+                .role(EditorRole.EDITOR) // 권한은 편집자를 기본값으로 부여
+                .status(InvitationStatus.PENDING)  // 초대 대기 상태를 기본값으로 설정
+                .build();
+
+        // 생성한 Editor 객체를 저장
+        Editor savedEditor = editorRepository.save(editor);
+
+        return EditorAddResponse.builder()
+                .message(editorUser.getNickname() + "님에게 초대를 보냈습니다.")
+                .editorId(savedEditor.getId())
+                .build();
+    }
+
+    
+    /**
+     * 사용자가 받은 초대 목록들을 조회하는 메서드
+     * @param userId : 사용자 아이디
+     * @param status : 초대 상태
+     * @return
+     */
+    public List<EditorSearchResponse> getUserInvitations(Long userId, String status) {
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // 초대 상태 조회
+        InvitationStatus invitationStatus = InvitationStatus.valueOf(status.toUpperCase());
+        // 초대 상태를 기준으로 해당 상태에 맞는 초대 목록들을 조회
+        List<Editor> invitations = editorRepository.findByUserAndStatusOrderByCreatedAtDesc(
+                user, invitationStatus);
+
+        // 초대 목록들을 반환
+        return invitations.stream()
+                .map(editor -> EditorSearchResponse.builder()
+                        .userId(editor.getTravelPlan().getUser().getId())
+                        .nickname(editor.getTravelPlan().getUser().getNickname())
+                        .profileImg(editor.getTravelPlan().getUser().getProfileImg())
+                        .email(editor.getTravelPlan().getUser().getEmail())
+                        .status(editor.getStatus())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+
+    /**
+     * 초대 대기 상태의 초대 목록들을 조회하는 메서드
+     * @param userId : 사용자 아이디
+     * @return : 초대 대기 상태의 초대 목록들을 반환
+     */
+    public List<EditorSearchResponse> getPendingInvitations(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        List<Editor> pendingInvitations = editorRepository.findByUserAndStatusOrderByCreatedAtDesc(
+                user, InvitationStatus.PENDING);
+
+        return pendingInvitations.stream()
+                .map(editor -> EditorSearchResponse.builder()
+                        .userId(editor.getTravelPlan().getUser().getId())
+                        .nickname(editor.getTravelPlan().getUser().getNickname())
+                        .profileImg(editor.getTravelPlan().getUser().getProfileImg())
+                        .email(editor.getTravelPlan().getUser().getEmail())
+                        .status(editor.getStatus())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+
+    /**
+     * 초대를 수락하는 메서드
+     * @param editorId : 초대받은 편집자의 아이디
+     * @param userId : 요청을 보내는 사용자 아이디, 초대 수락 기능을 이용할때 초대를 받은 사용자인지 확인하기 위해 사용함.
+     * @return : 초대 수락 혹은 권한없음 메시지
+     */
+    @Transactional
+    public EditorAddResponse acceptInvitation(Long editorId, Long userId) {
+        // 유효성 검증 로직들
+
+        // 1. 요청을 보낸 사용자와 편집자의 아이디가 일치하는지 확인
+        Editor editor = editorRepository.findById(editorId)
+                .orElseThrow(() -> new IllegalArgumentException("초대를 찾을 수 없습니다."));
+
+        // 2. 권한 확인: 해당 초대의 대상자인지 확인
+        if (!editor.getUser().getId().equals(userId)) { // 요청을 보낸 사용자와 편집자의 아이디가 일치하지 않는 경우
+            return EditorAddResponse.builder()
+                    .message("이 초대를 수락할 권한이 없습니다.")
+                    .build();
+        }
+
+        // 3. 이미 처리된 초대인지 확인
+        if (!editor.isPending()) { // status가 PENDING 상태가 아닌 경우
+            return EditorAddResponse.builder()
+                    .message("이미 처리된 초대입니다.")
+                    .build();
+        }
+
+        // 초대 수락
+        editor.acceptInvitation(); // 편집자의 초대 수락 여부를 ACCEPT로 변경
+        editorRepository.save(editor); // 해당 상태를 저장
+
+        return EditorAddResponse.builder()
+                .message("초대를 수락했습니다.")
+                .editorId(editor.getId())
+                .build();
+    }
+
+
+    /**
+     * 초대를 거절하는 메서드
+     * @param editorId : 초대받은 편집자의 아이디
+     * @param userId : 요청을 보내는 사용자 아이디, 초대 수락 기능을 이용할때 초대를 받은 사용자인지 확인하기 위해 사용함.
+     * @return : 초대 거절 혹은 권한없음 메시지
+     */
+    @Transactional
+    public EditorAddResponse rejectInvitation(Long editorId, Long userId) {
+        Editor editor = editorRepository.findById(editorId)
+                .orElseThrow(() -> new IllegalArgumentException("초대를 찾을 수 없습니다."));
+
+        // 권한 확인: 해당 초대의 대상자인지 확인
+        if (!editor.getUser().getId().equals(userId)) {
+            return EditorAddResponse.builder()
+                    .message("이 초대를 거절할 권한이 없습니다.")
+                    .build();
+        }
+
+        // 이미 처리된 초대인지 확인
+        if (!editor.isPending()) {
+            return EditorAddResponse.builder()
+                    .message("이미 처리된 초대입니다.")
+                    .build();
+        }
+
+        // 초대 거절후 저장
+        editor.rejectInvitation();
+        editorRepository.save(editor);
+
+        return EditorAddResponse.builder()
+                .message("초대를 거절했습니다.")
+                .editorId(editor.getId())
+                .build();
+    }
+
+    /**
+     * 여행계획의 편집자 목록을 조회하는 메서드 - 초대 수락 상태에 따라 조회
+     * @param travelPlanId : 여행계획 아이디
+     * @param status : 초대 수락 상태 - PENDING, REJECTED, ACCEPTED
+     * @return : status에 해당하는 편집자 목록들을 불러옴
+     */
+    public List<EditorSearchResponse> getEditorsByStatus(Long travelPlanId, String status) {
+        // 여행 계획 조회
+        TravelPlan travelPlan = travelPlanRepository.findById(travelPlanId)
+                .orElseThrow(() -> new IllegalArgumentException("여행 계획을 찾을 수 없습니다."));
+
+        // 초대 상태 조회
+        InvitationStatus invitationStatus = InvitationStatus.valueOf(status.toUpperCase());
+        // 초대 상태에 맞는 편집자 목록 조회
+        List<Editor> editors = editorRepository.findByTravelPlanAndStatus(
+                travelPlan, invitationStatus);
+        
+        return editors.stream()
+                .map(editor -> EditorSearchResponse.builder()
+                        .userId(editor.getUser().getId()) // 편집자의 userId
+                        .nickname(editor.getUser().getNickname()) // 편집자의 닉네임
+                        .profileImg(editor.getUser().getProfileImg()) // 편집자의 프로필 이미지
+                        .email(editor.getUser().getEmail()) // 편집자의 이메일
+                        .status(editor.getStatus())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 여행계획의 모든 초대 대상자(편집자) 목록을 조회하는 메서드 - 상태 구분 없이 전체 반환
+     * @param travelPlanId : 여행계획 아이디
+     * @return : 해당 여행계획에 초대된 모든 사용자 목록
+     */
+    public List<EditorSearchResponse> getEditors(Long travelPlanId) {
+        TravelPlan travelPlan = travelPlanRepository.findById(travelPlanId)
+                .orElseThrow(() -> new IllegalArgumentException("여행 계획을 찾을 수 없습니다."));
+
+        List<Editor> editors = editorRepository.findByTravelPlan(travelPlan);
+
+        return editors.stream()
+                .map(editor -> EditorSearchResponse.builder()
+                        .userId(editor.getUser().getId())
+                        .nickname(editor.getUser().getNickname())
+                        .profileImg(editor.getUser().getProfileImg())
+                        .email(editor.getUser().getEmail())
+                        .status(editor.getStatus())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+}

--- a/backend/truvel/src/main/java/alt_t/truvel/travelPlan/domain/entity/TravelPlan.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/travelPlan/domain/entity/TravelPlan.java
@@ -1,6 +1,7 @@
 package alt_t.truvel.travelPlan.domain.entity;
 
 import alt_t.truvel.daySchedule.DaySchedule;
+import alt_t.truvel.editor.domain.entity.Editor;
 import alt_t.truvel.location.Location;
 import alt_t.truvel.searchCountryAndCity.domain.entity.City;
 import alt_t.truvel.searchCountryAndCity.domain.entity.Country;
@@ -60,6 +61,10 @@ public class TravelPlan {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @Builder.Default
+    @OneToMany(mappedBy = "travelPlan", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Editor> editors = new ArrayList<>();
+
 
     // 생성자
     public TravelPlan(Long id, Country nationId, LocalDate startDate, LocalDate endDate, City cityId,
@@ -98,6 +103,13 @@ public class TravelPlan {
 
     // 사용자를 설정하는 메서드
     public void setUser(User user) {
+        this.user = user;
+    }
+
+    // 편집자 추가 메서드
+    public void addEditor(Editor editor) {
+        this.editors.add(editor);
+        editor.setTravelPlan(this);
     }
 
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#35 

## 📝작업 내용
1. Editor 엔티티 정의후 User, TravelPlan 엔티티와 연관관계 매핑
2. 친구검색, 여행계획에 친구추가, 초대받은 친구들 목록 조회 기능 구현

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
1. 친구 검색 기능
<img width="802" height="565" alt="스크린샷 2025-08-08 오후 2 37 21" src="https://github.com/user-attachments/assets/63b0dabe-be03-4477-a3e0-478de8303ffc" />

쿼리 파라미터를 이용하여 사용자의 닉네임을 검색하면 찾을 수 있습니다.


2. 친구 초대 기능
<img width="802" height="565" alt="스크린샷 2025-08-08 오후 2 37 36" src="https://github.com/user-attachments/assets/e1a777c5-4171-49a6-8f26-21c11f3ab663" />

Path Variables에서 travelPlanId를, request body에서 editorUserId를 입력합니다.
이때 editorUserId는 앞서 친구 검색 기능의 response body에서 나왔던 친구 사용자의 아이디를 의미합니다.


3. 초대 수락 및 거절 기능
<img width="802" height="565" alt="스크린샷 2025-08-08 오후 2 37 44" src="https://github.com/user-attachments/assets/dc17ca97-7cf0-409d-9707-325f643dd0ec" />
<img width="802" height="565" alt="스크린샷 2025-08-08 오후 2 37 49" src="https://github.com/user-attachments/assets/af594598-d9b6-4a9f-89c2-01acb3e179eb" />

해당 기능에서 editorId와 userId를 사용하고 있는데요. 이는 초대받은사람(editor)와 수락 요청을 보낸 사람(user)이 동일 사용자인지 판단하기 위해 사용합니다. 


4. 여행계획에서 초대받은 친구들 목록 조회 기능
<img width="802" height="565" alt="스크린샷 2025-08-08 오후 2 37 54" src="https://github.com/user-attachments/assets/b1d509ed-1352-488e-a318-a992f2909838" />

해당 여행계획에서 초대를 보낸 사용자 목록들을 확인할 수 있습니다. 


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
해당 기능의 request/response body 및 endpoint를 노션에 정리해두겠습니다.
