### PR TITLE
feat:지도 기능연동 및 관련 백앤드 수정 #81

### DIFF
--- a/backend/truvel/frontend/package-lock.json
+++ b/backend/truvel/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@react-google-maps/api": "^2.20.8",
         "@tanstack/react-query": "^5.80.2",
         "@tanstack/react-query-devtools": "^5.90.2",
         "axios": "^1.13.1",
@@ -555,6 +556,22 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@googlemaps/js-api-loader": {
+      "version": "1.16.8",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.8.tgz",
+      "integrity": "sha512-CROqqwfKotdO6EBjZO/gQGVTbeDps5V7Mt9+8+5Q+jTg5CRMi3Ii/L9PmV3USROrt2uWxtGzJHORmByxyo9pSQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@googlemaps/markerclusterer": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@googlemaps/markerclusterer/-/markerclusterer-2.5.3.tgz",
+      "integrity": "sha512-x7lX0R5yYOoiNectr10wLgCBasNcXFHiADIBdmn7jQllF2B5ENQw5XtZK+hIw4xnV0Df0xhN4LN98XqA5jaiOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "supercluster": "^8.0.1"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1246,6 +1263,36 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@react-google-maps/api": {
+      "version": "2.20.8",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/api/-/api-2.20.8.tgz",
+      "integrity": "sha512-wtLYFtCGXK3qbIz1H5to3JxbosPnKsvjDKhqGylXUb859EskhzR7OpuNt0LqdLarXUtZCJTKzPn3BNaekNIahg==",
+      "license": "MIT",
+      "dependencies": {
+        "@googlemaps/js-api-loader": "1.16.8",
+        "@googlemaps/markerclusterer": "2.5.3",
+        "@react-google-maps/infobox": "2.20.0",
+        "@react-google-maps/marker-clusterer": "2.20.0",
+        "@types/google.maps": "3.58.1",
+        "invariant": "2.2.4"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/@react-google-maps/infobox": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/infobox/-/infobox-2.20.0.tgz",
+      "integrity": "sha512-03PJHjohhaVLkX6+NHhlr8CIlvUxWaXhryqDjyaZ8iIqqix/nV8GFdz9O3m5OsjtxtNho09F/15j14yV0nuyLQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-google-maps/marker-clusterer": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/marker-clusterer/-/marker-clusterer-2.20.0.tgz",
+      "integrity": "sha512-tieX9Va5w1yP88vMgfH1pHTacDQ9TgDTjox3tLlisKDXRQWdjw+QeVVghhf5XqqIxXHgPdcGwBvKY6UP+SIvLw==",
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1600,6 +1647,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
       "dev": true
+    },
+    "node_modules/@types/google.maps": {
+      "version": "3.58.1",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
+      "integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
+      "license": "MIT"
     },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.6",
@@ -3706,8 +3759,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -4275,6 +4327,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -4700,8 +4761,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -4772,6 +4832,12 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -5073,7 +5139,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -6552,6 +6617,15 @@
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
       "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==",
       "license": "MIT"
+    },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/backend/truvel/frontend/package.json
+++ b/backend/truvel/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@react-google-maps/api": "^2.20.8",
     "@tanstack/react-query": "^5.80.2",
     "@tanstack/react-query-devtools": "^5.90.2",
     "axios": "^1.13.1",

--- a/backend/truvel/src/main/java/alt_t/truvel/location/controller/LocationController.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/location/controller/LocationController.java
@@ -23,8 +23,12 @@ public class LocationController {
     // 장소 검색
     @GetMapping("/search")
     @Operation(summary = "장소 검색", description = "구글 맵 API를 통해 장소를 검색합니다.")
-    public ResponseEntity<?> searchPlaces(@RequestParam String query) {
-        List<GooglePlaceResultDto> results = locationService.searchPlaces(query);
+    public ResponseEntity<?> searchPlaces(
+            @RequestParam String query,
+            @RequestParam(required = false) Double lat,
+            @RequestParam(required = false) Double lng
+    ) {
+        List<GooglePlaceResultDto> results = locationService.searchPlaces(query, lat, lng);
 
         return ResponseEntity.ok(results);
     }

--- a/backend/truvel/src/main/java/alt_t/truvel/location/locationDto/response/GooglePlaceResultDto.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/location/locationDto/response/GooglePlaceResultDto.java
@@ -1,3 +1,15 @@
 package alt_t.truvel.location.locationDto.response;
 
-public record GooglePlaceResultDto(String name, float latitude, float longitude, String address) {}
+import java.util.List;
+
+public record GooglePlaceResultDto(
+        String name,
+        float latitude,
+        float longitude,
+        String address,
+        Float rating,
+        Integer reviewCount,
+        List<String> types,
+        String photoReference,
+        Boolean openNow
+) {}

--- a/backend/truvel/src/main/java/alt_t/truvel/location/locationDto/response/GooglePlaceTextSearchResponseDto.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/location/locationDto/response/GooglePlaceTextSearchResponseDto.java
@@ -29,6 +29,46 @@ public class GooglePlaceTextSearchResponseDto {
 
         private Geometry geometry;
 
+        // 평점 (0.0 ~ 5.0)
+        private Float rating;
+
+        // 리뷰 수
+        @JsonProperty("user_ratings_total")
+        private Integer userRatingsTotal;
+
+        // 카테고리 (예: ["restaurant", "food", "point_of_interest"])
+        private List<String> types;
+
+        // 사진 정보
+        private List<Photo> photos;
+
+        // 가격대 (0 ~ 4)
+        @JsonProperty("price_level")
+        private Integer priceLevel;
+
+        // 영업 중 여부
+        @JsonProperty("opening_hours")
+        private OpeningHours openingHours;
+
+        @Getter
+        @NoArgsConstructor
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class Photo {
+            @JsonProperty("photo_reference")
+            private String photoReference;
+
+            private Integer height;
+            private Integer width;
+        }
+
+        @Getter
+        @NoArgsConstructor
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class OpeningHours {
+            @JsonProperty("open_now")
+            private Boolean openNow;
+        }
+
         @Getter
         @NoArgsConstructor
         @JsonIgnoreProperties(ignoreUnknown = true)

--- a/backend/truvel/src/main/java/alt_t/truvel/location/service/GooglePlaceClient.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/location/service/GooglePlaceClient.java
@@ -22,17 +22,44 @@ public class GooglePlaceClient {
     @Value("${spring.google.api.key}")
     private String apiKey;
 
-    public List<GooglePlaceResultDto> search(String query) {
-        String url = "https://maps.googleapis.com/maps/api/place/textsearch/json" +
-                "?query={query}" +
-                "&key={key}" +
-                "&language=ko";
+    public List<GooglePlaceResultDto> search(String query, Double lat, Double lng) {
+        StringBuilder urlBuilder = new StringBuilder("https://maps.googleapis.com/maps/api/place/textsearch/json");
+        urlBuilder.append("?query={query}");
+        
+        // 위치 정보가 있으면 location과 radius 파라미터 추가
+        if (lat != null && lng != null) {
+            urlBuilder.append("&location={lat},{lng}");
+            urlBuilder.append("&radius=10000"); // 10km 반경
+        }
+        
+        urlBuilder.append("&language=ko");
+        urlBuilder.append("&key={key}");
 
+        String url = urlBuilder.toString();
         System.out.println("[GooglePlaceClient] 요청 URL 템플릿: " + url);
+        System.out.println("[GooglePlaceClient] 검색 위치: lat=" + lat + ", lng=" + lng);
 
         try {
-            ResponseEntity<GooglePlaceTextSearchResponseDto> response =
-                    restTemplate.getForEntity(url, GooglePlaceTextSearchResponseDto.class, query, apiKey);
+            ResponseEntity<GooglePlaceTextSearchResponseDto> response;
+            
+            if (lat != null && lng != null) {
+                response = restTemplate.getForEntity(
+                    url, 
+                    GooglePlaceTextSearchResponseDto.class, 
+                    query, 
+                    lat, 
+                    lng, 
+                    apiKey
+                );
+            } else {
+                // 위치 정보 없으면 기존 방식
+                response = restTemplate.getForEntity(
+                    url, 
+                    GooglePlaceTextSearchResponseDto.class, 
+                    query, 
+                    apiKey
+                );
+            }
 
             GooglePlaceTextSearchResponseDto body = response.getBody();
             System.out.println("[GooglePlaceClient] 응답 body: " + body);
@@ -46,14 +73,31 @@ public class GooglePlaceClient {
                 throw new CustomException(ErrorCode.PLACE_NOT_FOUND);
             }
 
-            return body.getResults().stream().map(r ->
-                    new GooglePlaceResultDto(
-                            r.getName(),
-                            r.getGeometry().getLocation().getLat(),
-                            r.getGeometry().getLocation().getLng(),
-                            r.getFormattedAddress()
-                    )
-            ).toList();
+            return body.getResults().stream().map(r -> {
+                // 첫 번째 사진의 photo_reference 가져오기
+                String photoRef = null;
+                if (r.getPhotos() != null && !r.getPhotos().isEmpty()) {
+                    photoRef = r.getPhotos().get(0).getPhotoReference();
+                }
+
+                // 영업 중 여부
+                Boolean openNow = null;
+                if (r.getOpeningHours() != null) {
+                    openNow = r.getOpeningHours().getOpenNow();
+                }
+
+                return new GooglePlaceResultDto(
+                        r.getName(),
+                        r.getGeometry().getLocation().getLat(),
+                        r.getGeometry().getLocation().getLng(),
+                        r.getFormattedAddress(),
+                        r.getRating(),
+                        r.getUserRatingsTotal(),
+                        r.getTypes(),
+                        photoRef,
+                        openNow
+                );
+            }).toList();
 
         } catch (RestClientException e) {
             e.printStackTrace();

--- a/backend/truvel/src/main/java/alt_t/truvel/location/service/LocationService.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/location/service/LocationService.java
@@ -23,8 +23,8 @@ public class LocationService {
     private final ScheduleRepository scheduleRepository;
 
     // 장소 후보 검색
-    public List<GooglePlaceResultDto> searchPlaces(String query) {
-        return googlePlaceClient.search(query);
+    public List<GooglePlaceResultDto> searchPlaces(String query, Double lat, Double lng) {
+        return googlePlaceClient.search(query, lat, lng);
     }
 
     // 장소 저장

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@react-google-maps/api": "^2.20.8",
         "@tanstack/react-query": "^5.80.2",
         "@tanstack/react-query-devtools": "^5.90.2",
         "axios": "^1.13.1",
@@ -555,6 +556,22 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@googlemaps/js-api-loader": {
+      "version": "1.16.8",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.8.tgz",
+      "integrity": "sha512-CROqqwfKotdO6EBjZO/gQGVTbeDps5V7Mt9+8+5Q+jTg5CRMi3Ii/L9PmV3USROrt2uWxtGzJHORmByxyo9pSQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@googlemaps/markerclusterer": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@googlemaps/markerclusterer/-/markerclusterer-2.5.3.tgz",
+      "integrity": "sha512-x7lX0R5yYOoiNectr10wLgCBasNcXFHiADIBdmn7jQllF2B5ENQw5XtZK+hIw4xnV0Df0xhN4LN98XqA5jaiOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "supercluster": "^8.0.1"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1246,6 +1263,36 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@react-google-maps/api": {
+      "version": "2.20.8",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/api/-/api-2.20.8.tgz",
+      "integrity": "sha512-wtLYFtCGXK3qbIz1H5to3JxbosPnKsvjDKhqGylXUb859EskhzR7OpuNt0LqdLarXUtZCJTKzPn3BNaekNIahg==",
+      "license": "MIT",
+      "dependencies": {
+        "@googlemaps/js-api-loader": "1.16.8",
+        "@googlemaps/markerclusterer": "2.5.3",
+        "@react-google-maps/infobox": "2.20.0",
+        "@react-google-maps/marker-clusterer": "2.20.0",
+        "@types/google.maps": "3.58.1",
+        "invariant": "2.2.4"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/@react-google-maps/infobox": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/infobox/-/infobox-2.20.0.tgz",
+      "integrity": "sha512-03PJHjohhaVLkX6+NHhlr8CIlvUxWaXhryqDjyaZ8iIqqix/nV8GFdz9O3m5OsjtxtNho09F/15j14yV0nuyLQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-google-maps/marker-clusterer": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/marker-clusterer/-/marker-clusterer-2.20.0.tgz",
+      "integrity": "sha512-tieX9Va5w1yP88vMgfH1pHTacDQ9TgDTjox3tLlisKDXRQWdjw+QeVVghhf5XqqIxXHgPdcGwBvKY6UP+SIvLw==",
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1600,6 +1647,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
       "dev": true
+    },
+    "node_modules/@types/google.maps": {
+      "version": "3.58.1",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
+      "integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
+      "license": "MIT"
     },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.6",
@@ -3706,8 +3759,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -4275,6 +4327,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -4700,8 +4761,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -4772,6 +4832,12 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -5073,7 +5139,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -6552,6 +6617,15 @@
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
       "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==",
       "license": "MIT"
+    },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@react-google-maps/api": "^2.20.8",
     "@tanstack/react-query": "^5.80.2",
     "@tanstack/react-query-devtools": "^5.90.2",
     "axios": "^1.13.1",

--- a/frontend/src/app/my-trips/map/components/GoogleMapComponent.tsx
+++ b/frontend/src/app/my-trips/map/components/GoogleMapComponent.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { useState, useCallback, memo, useEffect } from 'react';
+import { GoogleMap, LoadScript, Marker, InfoWindow } from '@react-google-maps/api';
+
+interface GoogleMapComponentProps {
+  selectedPlace?: {
+    name: string;
+    address: string;
+    latitude: number;
+    longitude: number;
+  } | null;
+  selectedPlaces?: Array<{
+    name: string;
+    address: string;
+    latitude: number;
+    longitude: number;
+  }>;
+  initialCityName?: string | null;
+  onCityCenterChange?: (center: { lat: number; lng: number } | null) => void;
+}
+
+const containerStyle = {
+  width: '100%',
+  height: '100%',
+};
+
+// 기본 중심 좌표 (서울)
+const defaultCenter = {
+  lat: 37.5665,
+  lng: 126.9780,
+};
+
+const GoogleMapComponent = ({ selectedPlace, selectedPlaces = [], initialCityName, onCityCenterChange }: GoogleMapComponentProps) => {
+  const [map, setMap] = useState<google.maps.Map | null>(null);
+  const [cityCenter, setCityCenter] = useState<{ lat: number; lng: number } | null>(null);
+  const [isLoadingCity, setIsLoadingCity] = useState(false);
+
+  // 구글 맵 API 로드 완료 후 초기 도시 좌표 얻기
+  const handleMapLoad = useCallback(() => {
+    if (initialCityName && !cityCenter && typeof window !== 'undefined' && window.google) {
+      setIsLoadingCity(true);
+      const geocoder = new window.google.maps.Geocoder();
+      
+      geocoder.geocode({ address: initialCityName }, (results, status) => {
+        if (status === 'OK' && results && results[0]) {
+          const location = results[0].geometry.location;
+          const newCenter = {
+            lat: location.lat(),
+            lng: location.lng(),
+          };
+          setCityCenter(newCenter);
+          onCityCenterChange?.(newCenter);
+          console.log(`📍 ${initialCityName} 좌표:`, newCenter);
+        } else {
+          console.error('❌ Geocoding 실패:', status);
+        }
+        setIsLoadingCity(false);
+      });
+    }
+  }, [initialCityName, cityCenter, onCityCenterChange]);
+
+  // 현재 표시할 중심 좌표 결정 (우선순위: 선택된 장소 > 선택된 장소 목록 > 초기 도시 > 기본 위치)
+  const center = selectedPlace
+    ? { lat: selectedPlace.latitude, lng: selectedPlace.longitude }
+    : selectedPlaces.length > 0
+    ? { lat: selectedPlaces[0].latitude, lng: selectedPlaces[0].longitude }
+    : cityCenter || defaultCenter;
+
+  const onLoad = useCallback((map: google.maps.Map) => {
+    setMap(map);
+  }, []);
+
+  const onUnmount = useCallback(() => {
+    setMap(null);
+  }, []);
+
+  // API 키 확인
+  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+
+  if (!apiKey) {
+    return (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: '#f0f0f0',
+          color: '#666',
+          fontSize: '14px',
+          textAlign: 'center',
+          padding: '20px',
+        }}
+      >
+        <div>
+          <p style={{ marginBottom: '10px', fontWeight: 'bold' }}>
+            ⚠️ Google Maps API 키가 설정되지 않았습니다
+          </p>
+          <p style={{ fontSize: '12px', lineHeight: '1.5' }}>
+            frontend/.env.local 파일에<br />
+            NEXT_PUBLIC_GOOGLE_MAPS_API_KEY를 설정해주세요
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <LoadScript 
+      googleMapsApiKey={apiKey}
+      onLoad={handleMapLoad}
+    >
+      <GoogleMap
+        mapContainerStyle={containerStyle}
+        center={center}
+        zoom={13}
+        onLoad={onLoad}
+        onUnmount={onUnmount}
+        options={{
+          disableDefaultUI: false,
+          zoomControl: true,
+          streetViewControl: false,
+          mapTypeControl: false,
+          fullscreenControl: false,
+        }}
+      >
+        {/* 현재 선택된 장소에 마커 표시 */}
+        {selectedPlace && (
+          <>
+            <Marker
+              position={{
+                lat: selectedPlace.latitude,
+                lng: selectedPlace.longitude,
+              }}
+              animation={google.maps.Animation.DROP}
+            />
+            <InfoWindow
+              position={{
+                lat: selectedPlace.latitude,
+                lng: selectedPlace.longitude,
+              }}
+              options={{
+                pixelOffset: new google.maps.Size(0, -35), // 마커 위에 표시
+              }}
+            >
+              <div
+                style={{
+                  background: 'white',
+                  padding: '1px 12px',
+                  borderRadius: '6px',
+                  maxWidth: '280px',
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: '14px',
+                    fontWeight: '600',
+                    marginBottom: '2px',
+                    color: '#1C1C1C',
+                    lineHeight: '1.1',
+                  }}
+                >
+                  {selectedPlace.name}
+                </div>
+                <div
+                  style={{
+                    fontSize: '12px',
+                    color: '#1C1C1C',
+                    lineHeight: '1.4',
+                  }}
+                >
+                  {selectedPlace.address}
+                </div>
+              </div>
+            </InfoWindow>
+          </>
+        )}
+
+        {/* 선택된 모든 장소에 마커 표시 */}
+        {selectedPlaces.map((place, index) => (
+          <Marker
+            key={`${place.name}-${index}`}
+            position={{
+              lat: place.latitude,
+              lng: place.longitude,
+            }}
+            label={{
+              text: `${index + 1}`,
+              color: 'white',
+              fontWeight: 'bold',
+            }}
+          />
+        ))}
+      </GoogleMap>
+    </LoadScript>
+  );
+};
+
+export default memo(GoogleMapComponent);
+

--- a/frontend/src/app/my-trips/map/components/LocationSearchInput.tsx
+++ b/frontend/src/app/my-trips/map/components/LocationSearchInput.tsx
@@ -1,117 +1,126 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { useSearchPlaces } from '@/lib/hooks/useLocation';
+import { GooglePlaceResult } from '@/lib/api/location';
 
 interface LocationSearchInputProps {
-  onSelect: (place: { name: string; address: string }) => void;
+  onSelect: (place: { name: string; address: string; latitude: number; longitude: number }) => void;
   selectedPlaces?: { name: string; address: string }[];
   onClear?: () => void; 
   onSearchStart?: () => void;
+  searchCenter?: { lat: number; lng: number } | null;
 }
 
-interface SearchResult {
-  name: string;
-  address: string;
+interface SearchResult extends GooglePlaceResult {
   rating?: number;
   reviewCount?: number;
   category?: string;
   images: string[];
 }
 
-export default function LocationSearchInput({ onSelect, selectedPlaces = [], onClear, onSearchStart }: LocationSearchInputProps) {
+type SortType = 'none' | 'openNow' | 'rating' | 'reviewCount';
+
+export default function LocationSearchInput({ onSelect, selectedPlaces = [], onClear, onSearchStart, searchCenter }: LocationSearchInputProps) {
   const [input, setInput] = useState('');
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
-  const [isSearching, setIsSearching] = useState(false);
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [sortType, setSortType] = useState<SortType>('none');
+  
+  // 디바운싱: 입력 후 500ms 대기
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedQuery(input.trim());
+    }, 500);
 
-  // 검색 결과 시뮬레이션 (실제로는 API 호출)
-  const mockSearchResults: SearchResult[] = [
-    {
-      name: "도쿄 디즈니씨",
-      address: "일본 도쿄도 우라야스시",
-      rating: 4.8,
-      reviewCount: 1228,
-      category: "테마 (음식점, 관광명소, 쇼핑, 체험 등)",
-      images: ["/icons/blank.png", "/icons/blank.png", "/icons/blank.png", "/icons/blank.png", "/icons/blank.png"]
-    },
-    {
-      name: "도쿄 디즈니랜드",
-      address: "일본 도쿄도 우라야스시",
-      rating: 4.7,
-      reviewCount: 1156,
-      category: "테마 (음식점, 관광명소, 쇼핑, 체험 등)",
-      images: ["/icons/blank.png", "/icons/blank.png", "/icons/blank.png", "/icons/blank.png"]
-    },
-    {
-      name: "도쿄 타워",
-      address: "일본 도쿄도 미나토구",
-      rating: 4.6,
-      reviewCount: 892,
-      category: "관광명소, 전망대",
-      images: ["/icons/blank.png", "/icons/blank.png", "/icons/blank.png"]
-    },
-    {
-      name: "시부야 스크램블 교차로",
-      address: "일본 도쿄도 시부야구",
-      rating: 4.5,
-      reviewCount: 756,
-      category: "관광명소, 도시경관",
-      images: ["/icons/blank.png", "/icons/blank.png", "/icons/blank.png", "/icons/blank.png"]
-    },
-    {
-      name: "하라주쿠",
-      address: "일본 도쿄도 시부야구",
-      rating: 4.4,
-      reviewCount: 634,
-      category: "쇼핑, 문화",
-      images: ["/icons/blank.png", "/icons/blank.png", "/icons/blank.png"]
+    return () => clearTimeout(timer);
+  }, [input]);
+
+  // 실제 API 호출 (도시 좌표를 포함하여 검색)
+  const { data: apiResults, isLoading, error } = useSearchPlaces(
+    debouncedQuery, 
+    searchCenter?.lat, 
+    searchCenter?.lng, 
+    debouncedQuery.length > 0
+  );
+
+  // 구글 API 키 (사진 URL 생성용)
+  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+
+  // 카테고리 타입을 한국어로 변환
+  const translateTypes = (types?: string[] | null): string => {
+    if (!types || types.length === 0) return "장소";
+    
+    const typeMap: { [key: string]: string } = {
+      restaurant: "음식점",
+      cafe: "카페",
+      food: "음식점",
+      lodging: "숙박",
+      tourist_attraction: "관광명소",
+      amusement_park: "테마파크",
+      museum: "박물관",
+      park: "공원",
+      shopping_mall: "쇼핑몰",
+      store: "상점",
+      bar: "바",
+      night_club: "나이트클럽",
+      point_of_interest: "관심지점",
+    };
+
+    const translated = types
+      .map(type => typeMap[type])
+      .filter(Boolean);
+
+    // 중복 제거
+    const unique = [...new Set(translated)];
+    
+    // 최대 3개까지만
+    return unique.length > 0 ? unique.slice(0, 3).join(", ") : "장소";
+  };
+
+  // API 결과를 UI 형식으로 변환
+  useEffect(() => {
+    if (apiResults && apiResults.length > 0) {
+      const formattedResults: SearchResult[] = apiResults.map(result => {
+        // 구글 사진 URL 생성
+        const imageUrl = result.photoReference && apiKey
+          ? `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${result.photoReference}&key=${apiKey}`
+          : "/icons/blank.png";
+
+        return {
+          ...result,
+          rating: result.rating || undefined,
+          reviewCount: result.reviewCount || undefined,
+          category: translateTypes(result.types),
+          images: [imageUrl],
+        };
+      });
+      setSearchResults(formattedResults);
+    } else if (debouncedQuery.length > 0 && !isLoading) {
+      setSearchResults([]);
     }
-  ];
+  }, [apiResults, debouncedQuery, isLoading, apiKey]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setInput(value);
     
-    if (value) { // 빈 문자열이 아니면 무조건 검색 (숫자만 있어도 됨)
+    if (value) {
       if (onSearchStart) onSearchStart();
-      handleSearch();
       // 검색 중일 때는 현재 핀을 숨김
       if (onClear) onClear();
     } else {
       setSearchResults([]);
-      setIsSearching(false);
+      setDebouncedQuery('');
       if (onClear) onClear();
     }
-  };
-
-  const handleSearch = () => {
-    const trimmed = input.trim();
-    if (!trimmed) { // 빈 문자열이 아니면 무조건 검색
-      setSearchResults([]);
-      setIsSearching(false);
-      return;
-    }
-
-    setIsSearching(true);
-    // 실제 검색 API 호출 대신 시뮬레이션
-    setTimeout(() => {
-      // 입력된 텍스트가 포함된 결과만 필터링 (숫자도 포함)
-      const filteredResults = mockSearchResults.filter(result => 
-        result.name.toLowerCase().includes(trimmed.toLowerCase()) ||
-        result.address.toLowerCase().includes(trimmed.toLowerCase()) ||
-        result.category?.toLowerCase().includes(trimmed.toLowerCase()) ||
-        result.rating?.toString().includes(trimmed) ||
-        result.reviewCount?.toString().includes(trimmed)
-      );
-      setSearchResults(filteredResults);
-      setIsSearching(false);
-    }, 500);
   };
 
   const handleClear = () => {
     setInput('');
     setSearchResults([]);
-    setIsSearching(false);
+    setDebouncedQuery('');
     if (onClear) onClear();
   };
 
@@ -125,17 +134,55 @@ export default function LocationSearchInput({ onSelect, selectedPlaces = [], onC
       onSelect({
         name: place.name,
         address: place.address,
+        latitude: place.latitude,
+        longitude: place.longitude,
       });
     }
     
     setInput('');
     setSearchResults([]);
-    setIsSearching(false);
+    setDebouncedQuery('');
   };
 
-  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') handleSearch();
+  // 정렬/필터 함수
+  const getSortedResults = () => {
+    if (!searchResults || searchResults.length === 0) return [];
+
+    let sorted = [...searchResults];
+
+    switch (sortType) {
+      case 'openNow':
+        // 영업 중인 것들을 위로
+        sorted.sort((a, b) => {
+          if (a.openNow === b.openNow) return 0;
+          return a.openNow ? -1 : 1;
+        });
+        break;
+      case 'rating':
+        // 평점 높은 순
+        sorted.sort((a, b) => {
+          const ratingA = a.rating || 0;
+          const ratingB = b.rating || 0;
+          return ratingB - ratingA;
+        });
+        break;
+      case 'reviewCount':
+        // 리뷰 많은 순
+        sorted.sort((a, b) => {
+          const countA = a.reviewCount || 0;
+          const countB = b.reviewCount || 0;
+          return countB - countA;
+        });
+        break;
+      default:
+        // 정렬 없음 (원래 순서)
+        break;
+    }
+
+    return sorted;
   };
+
+  const displayedResults = getSortedResults();
 
   return (
     <Container>
@@ -145,12 +192,11 @@ export default function LocationSearchInput({ onSelect, selectedPlaces = [], onC
           placeholder="장소 이름, 주소를 입력해주세요"
           value={input}
           onChange={handleInputChange}
-          onKeyPress={handleKeyPress}
         />
         {input && (
           <ClearButton onClick={handleClear}>✕</ClearButton>
         )}
-        <SearchIcon src="/icons/Search_light.png" alt="검색" onClick={handleSearch} />
+        <SearchIcon src="/icons/Search_light.png" alt="검색" />
       </InputContainer>
 
       {/* 검색 결과 - 아래에서 올라오는 형태 */}
@@ -160,15 +206,30 @@ export default function LocationSearchInput({ onSelect, selectedPlaces = [], onC
     
         <StickyBar>
           <FilterButtons>
-            <FilterButton>지금 영업 중</FilterButton>
-            <FilterButton>최고 평점</FilterButton>
-            <FilterButton>리뷰 수</FilterButton>
+            <FilterButton 
+              $active={sortType === 'openNow'}
+              onClick={() => setSortType(sortType === 'openNow' ? 'none' : 'openNow')}
+            >
+              지금 영업 중
+            </FilterButton>
+            <FilterButton 
+              $active={sortType === 'rating'}
+              onClick={() => setSortType(sortType === 'rating' ? 'none' : 'rating')}
+            >
+              최고 평점
+            </FilterButton>
+            <FilterButton 
+              $active={sortType === 'reviewCount'}
+              onClick={() => setSortType(sortType === 'reviewCount' ? 'none' : 'reviewCount')}
+            >
+              리뷰 수
+            </FilterButton>
             <ClearFilterButton onClick={() => setSearchResults([])}>✕</ClearFilterButton>
           </FilterButtons>
         </StickyBar>
     
         <ResultsList>
-        {searchResults.map((result, index) => (
+        {displayedResults.map((result, index) => (
     <ResultItem key={index} onClick={() => handleSelectPlace(result)}>
       {/* 가로 스크롤 썸네일 */}
       <ResultImagesContainer>
@@ -190,7 +251,7 @@ export default function LocationSearchInput({ onSelect, selectedPlaces = [], onC
             {result.rating} ({result.reviewCount?.toLocaleString() || 0})
             <StarIcon>⭐</StarIcon>
           </ResultRating>
-          <ResultAddress>📍 장소의 상세 주소 입력칸</ResultAddress>
+          <ResultAddress>📍 {result.address}</ResultAddress>
         </ResultContent>
 
         <SelectButton type="button">선택</SelectButton>
@@ -202,9 +263,16 @@ export default function LocationSearchInput({ onSelect, selectedPlaces = [], onC
       )}
 
       {/* 로딩 상태 */}
-      {isSearching && (
+      {isLoading && debouncedQuery && (
         <LoadingContainer>
           <LoadingText>검색 중...</LoadingText>
+        </LoadingContainer>
+      )}
+
+      {/* 에러 상태 */}
+      {error && debouncedQuery && (
+        <LoadingContainer>
+          <LoadingText style={{ color: '#ef4444' }}>검색 결과를 불러올 수 없습니다.</LoadingText>
         </LoadingContainer>
       )}
     </Container>
@@ -321,15 +389,20 @@ const FilterButtons = styled.div`
   }
 `;
 
-const FilterButton = styled.button`
+const FilterButton = styled.button<{ $active?: boolean }>`
   padding: 10px 14px;
-  background: #f8f9fa;
-  border: 1px solid #e9ecef;
+  background: ${({ $active }) => $active ? '#3CA6FF' : '#f8f9fa'};
+  border: 1px solid ${({ $active }) => $active ? '#3CA6FF' : '#e9ecef'};
   border-radius: 20px;
   font-size: 14px;
-  color: #495057;
+  color: ${({ $active }) => $active ? 'white' : '#495057'};
   white-space: nowrap;
   flex-shrink: 0;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: ${({ $active }) => $active ? '#3295e6' : '#e9ecef'};
+  }
 
   @media (min-width: 768px) {
     padding: 12px 18px;

--- a/frontend/src/app/my-trips/map/page.tsx
+++ b/frontend/src/app/my-trips/map/page.tsx
@@ -1,19 +1,51 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
 import { useRouter } from 'next/navigation';
+import dynamic from 'next/dynamic';
 import LocationSearchInput from './components/LocationSearchInput';
+
+// 구글 맵을 클라이언트 사이드에서만 로드 (SSR 방지)
+const GoogleMapComponent = dynamic(
+  () => import('./components/GoogleMapComponent'),
+  { ssr: false, loading: () => <div style={{ width: '100%', height: '100%', background: '#f0f0f0' }}>지도 로딩 중...</div> }
+);
 
 export default function Page() {
   const router = useRouter();
   const [selectedPlaces, setSelectedPlaces] = useState<
-    { name: string; address: string; image?: string }[]
+    { name: string; address: string; latitude: number; longitude: number; image?: string }[]
   >([]);
-  const [currentPin, setCurrentPin] = useState<{ name: string; address: string } | null>(null);
+  const [currentPin, setCurrentPin] = useState<{ name: string; address: string; latitude: number; longitude: number } | null>(null);
   const [isSearching, setIsSearching] = useState(false);
+  const [initialCity, setInitialCity] = useState<string | null>(null);
+  const [cityCenter, setCityCenter] = useState<{ lat: number; lng: number } | null>(null);
 
-  const handleSelect = (place: { name: string; address: string }) => {
+  // popular에서 선택한 도시 정보 읽기
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const selectedCitiesStr = sessionStorage.getItem('selectedCities');
+      if (selectedCitiesStr) {
+        try {
+          const selectedCities = JSON.parse(selectedCitiesStr);
+          if (selectedCities && selectedCities.length > 0) {
+            // 첫 번째 선택된 도시로 초기 중심 설정
+            setInitialCity(selectedCities[0].name);
+          }
+        } catch (e) {
+          console.error('Failed to parse selected cities', e);
+        }
+      }
+    }
+  }, []);
+
+  // 도시 중심 좌표 변경 핸들러
+  const handleCityCenterChange = useCallback((center: { lat: number; lng: number } | null) => {
+    setCityCenter(center);
+  }, []);
+
+  const handleSelect = (place: { name: string; address: string; latitude: number; longitude: number }) => {
     const isDuplicate = selectedPlaces.some(
       (p) => p.name === place.name && p.address === place.address
     );
@@ -45,7 +77,11 @@ export default function Page() {
     }
     
     if (selectedPlaces.length > 0) {
-      router.push('/my-trips/optimize');
+      // 선택한 장소들을 sessionStorage에 저장
+      if (typeof window !== 'undefined') {
+        sessionStorage.setItem('selectedPlaces', JSON.stringify(selectedPlaces));
+      }
+      router.push('optimize/route');
     }
   };
 
@@ -59,7 +95,17 @@ export default function Page() {
   };
 
   return (
-    <FullScreenBackground>
+    <FullScreenContainer>
+      {/* 구글 맵 배경 */}
+      <MapContainer>
+        <GoogleMapComponent 
+          selectedPlace={currentPin}
+          selectedPlaces={selectedPlaces}
+          initialCityName={initialCity}
+          onCityCenterChange={handleCityCenterChange}
+        />
+      </MapContainer>
+
       <OverlayContent>
         {/* 모바일 스타일 헤더 - 화면 전체 너비 */}
         <MobileHeader>
@@ -78,20 +124,9 @@ export default function Page() {
             selectedPlaces={selectedPlaces}
             onClear={handleClear}
             onSearchStart={handleSearchStart}
+            searchCenter={cityCenter}
           />
         </SearchSection>
-
-        {/* 현재 선택된 장소 핀과 정보 박스 */}
-        {currentPin && !isSearching && (
-          <PinAndBoxWrapper>
-            <BoxBackground src="/icons/box.png" alt="box" />
-            <BoxContent>
-              <PlaceName>{currentPin.name}</PlaceName>
-              <PlaceAddress>{currentPin.address}</PlaceAddress>
-            </BoxContent>
-            <PinIcon src="/icons/pin.png" alt="pin" />
-          </PinAndBoxWrapper>
-        )}
 
         {/* 하단 액션 섹션 - 검색 중일 때는 숨김 */}
         {!isSearching && (
@@ -114,19 +149,24 @@ export default function Page() {
           </BottomActionSection>
         )}
       </OverlayContent>
-    </FullScreenBackground>
+    </FullScreenContainer>
   );
 }
 
-const FullScreenBackground = styled.div`
+const FullScreenContainer = styled.div`
   position: relative;
   width: 100%;
   height: 100dvh;
-  background-image: url('/icons/EXmap.png');
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
   overflow: hidden;
+`;
+
+const MapContainer = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 0;
 `;
 
 const OverlayContent = styled.div`
@@ -139,6 +179,13 @@ const OverlayContent = styled.div`
   flex-direction: column;
   background: transparent;
   box-sizing: border-box;
+  z-index: 1;
+  pointer-events: none; // 지도 클릭 가능하도록
+
+  // 자식 요소들은 클릭 가능하도록
+  > * {
+    pointer-events: auto;
+  }
 `;
 
 const MobileHeader = styled.div`
@@ -330,55 +377,3 @@ const AddButton = styled.button`
   }
 `;
 
-const PinAndBoxWrapper = styled.div`
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  display: flex;
-  flex-direction: column-reverse;
-  align-items: center;
-  z-index: 10;
-`;
-
-const PinIcon = styled.img`
-  width: 28px;
-  height: 36px;
-  z-index: 2;
-  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
-`;
-
-const BoxBackground = styled.img`
-  width: 280px;
-  height: auto;
-  position: absolute;
-  top: -100px;
-  z-index: 1;
-  filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.15));
-`;
-
-const BoxContent = styled.div`
-  position: absolute;
-  top: -100px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 280px;
-  padding: 16px;
-  z-index: 2;
-`;
-
-const PlaceName = styled.div`
-  font-size: 16px;
-  font-weight: 600;
-  margin-bottom: 6px;
-  color: #1C1C1C;
-  text-align: center;
-`;
-
-const PlaceAddress = styled.div`
-  font-size: 14px;
-  color: #666;
-  text-align: center;
-  line-height: 1.4;
-`;

--- a/frontend/src/lib/api/location.ts
+++ b/frontend/src/lib/api/location.ts
@@ -1,0 +1,68 @@
+import apiClient from '../axios';
+
+// 타입 정의
+export interface GooglePlaceResult {
+  name: string;
+  latitude: number;
+  longitude: number;
+  address: string;
+  rating?: number | null;
+  reviewCount?: number | null;
+  types?: string[] | null;
+  photoReference?: string | null;
+  openNow?: boolean | null;
+}
+
+export type PlaceCategory = 'DEFAULT' | 'CAFE' | 'RESTAURANT' | 'ATTRACTION';
+
+export interface LocationSaveRequest {
+  name: string;
+  latitude: number;
+  longitude: number;
+  address: string;
+  category?: PlaceCategory;
+}
+
+export interface LocationResponse {
+  locationId: number;
+  place: string;
+  latitude: number;
+  longitude: number;
+  address: string;
+  category: string;
+}
+
+// 장소 검색 API
+export const searchPlaces = async (
+  query: string, 
+  lat?: number, 
+  lng?: number
+): Promise<GooglePlaceResult[]> => {
+  const params: any = { query };
+  if (lat !== undefined && lng !== undefined) {
+    params.lat = lat;
+    params.lng = lng;
+  }
+  
+  const response = await apiClient.get<GooglePlaceResult[]>('/locations/search', { params });
+  return response.data;
+};
+
+// 장소 저장 API
+export const saveLocations = async (locations: LocationSaveRequest[]): Promise<LocationResponse[]> => {
+  const response = await apiClient.post<LocationResponse[]>('/locations', locations);
+  return response.data;
+};
+
+// 장소 목록 조회 API
+export const getLocations = async (travelPlanId: number): Promise<LocationResponse[]> => {
+  const response = await apiClient.get<LocationResponse[]>(`/locations/getLocations/${travelPlanId}`);
+  return response.data;
+};
+
+// 장소 삭제 API
+export const deleteLocation = async (locationId: number): Promise<string> => {
+  const response = await apiClient.delete<string>(`/locations/${locationId}`);
+  return response.data;
+};
+

--- a/frontend/src/lib/hooks/useLocation.ts
+++ b/frontend/src/lib/hooks/useLocation.ts
@@ -1,0 +1,65 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { 
+  searchPlaces, 
+  saveLocations, 
+  getLocations, 
+  deleteLocation,
+  LocationSaveRequest,
+  GooglePlaceResult,
+  LocationResponse
+} from '../api/location';
+
+// 장소 검색 훅
+export const useSearchPlaces = (
+  query: string, 
+  lat?: number, 
+  lng?: number, 
+  enabled: boolean = true
+) => {
+  return useQuery({
+    queryKey: ['searchPlaces', query, lat, lng],
+    queryFn: () => searchPlaces(query, lat, lng),
+    enabled: enabled && query.length > 0,
+    staleTime: 30 * 1000, // 30초
+  });
+};
+
+// 장소 저장 훅
+export const useSaveLocations = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: (locations: LocationSaveRequest[]) => saveLocations(locations),
+    onSuccess: () => {
+      // 저장 성공 시 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: ['locations'] });
+    },
+  });
+};
+
+// 장소 목록 조회 훅
+export const useLocations = (travelPlanId: number | null) => {
+  return useQuery({
+    queryKey: ['locations', travelPlanId],
+    queryFn: () => {
+      if (!travelPlanId) throw new Error('Travel plan ID is required');
+      return getLocations(travelPlanId);
+    },
+    enabled: !!travelPlanId,
+    staleTime: 60 * 1000, // 1분
+  });
+};
+
+// 장소 삭제 훅
+export const useDeleteLocation = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: (locationId: number) => deleteLocation(locationId),
+    onSuccess: () => {
+      // 삭제 성공 시 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: ['locations'] });
+    },
+  });
+};
+


### PR DESCRIPTION
프론트 
지도 검색 및 구글 api 맵 기능연동 진행 

백앤드 
백앤드쪽 location 파일 수정 
-구글 Places API는 평점, 리뷰 수, 카테고리, 사진 등을 제공하고 본 서비스에서 사용해야 하는데 
-백엔드쪽에서 이 정보들을 파싱하지 않고 name, address만 프론트엔드로 보내고 있었음 
-또한 현재 장소 검색시에 한국기준으로 돼어있어서 장소 검색시에 여행할 도시의 좌표를 토대로 검색창에 뜨게끔 수정 (여행지 좌표 기준 검색)