### PR TITLE
fix:인증용 메일 통일화

### DIFF
--- a/backend/truvel/src/main/java/alt_t/truvel/auth/emailVerification/service/EmailVerificationService.java
+++ b/backend/truvel/src/main/java/alt_t/truvel/auth/emailVerification/service/EmailVerificationService.java
@@ -60,7 +60,7 @@ public class EmailVerificationService {
 
         emailSenderService.sendEmail(
                 email,
-                "Truvel 이메일 인증 코드",
+                "Truvel 이메일 인증 코드입니다.",
                 "인증 코드: " + code + "\n10분 내로 입력해주세요."
         );
     }

--- a/frontend/src/lib/hooks/useAuth.ts
+++ b/frontend/src/lib/hooks/useAuth.ts
@@ -39,13 +39,7 @@ export const useSignup = () => {
         sessionStorage.setItem('pendingLoginPassword', data.password);
       }
       
-      // 회원가입 성공 후 이메일 인증 코드 발송
-      try {
-        await sendVerificationCode(data.email);
-      } catch (emailError) {
-        console.error('이메일 발송 실패:', emailError);
-        // 이메일 발송 실패해도 회원가입은 성공했으므로 계속 진행
-      }
+      // 이메일 발송은 verify 페이지에서 자동으로 처리되므로 여기서는 제거
       
       return signupResponse;
     },


### PR DESCRIPTION
프론트
회원가입 성공시와 메일 인증 화면 에서 따로따로 인증메일을 보내 2번 보냈던걸 1번만 보내게 수정 

백앤드 
<img width="796" height="235" alt="스크린샷 2025-12-17 183109" src="https://github.com/user-attachments/assets/51bd7180-11a3-47c0-aa97-9216704e1d6a" />
사진과 같이 새로 생성할때와 재전송할때 다르게 표시되던걸 통일화