### PR TITLE
feat:프론트 유닛,통합 테스트 #98

### DIFF
--- a/frontend/src/app/my-trips/__tests__/page.test.tsx
+++ b/frontend/src/app/my-trips/__tests__/page.test.tsx
@@ -1,0 +1,143 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders } from "@/test/test-utils";
+import { server } from "@/mocks/server";
+
+// ─── Next.js 모킹 ───────────────────────────────────────────
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    back: vi.fn(),
+  }),
+}));
+
+vi.mock("next/image", () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => {
+    return <img {...props} alt={props.alt || ""} />;
+  },
+}));
+
+import MyTripsPage from "../page";
+
+// ─── MSW ─────────────────────────────────────────────────────
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("MyTripsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 통합 테스트: 여행 목록 조회
+  // ═══════════════════════════════════════════════════════════
+
+  describe("여행 목록 조회", () => {
+    it("로딩 중일 때 로딩 메시지가 표시된다", () => {
+      renderWithProviders(<MyTripsPage />);
+
+      expect(screen.getByText("여행 일정을 불러오는 중...")).toBeInTheDocument();
+    });
+
+    it("여행 목록이 정상적으로 렌더링된다", async () => {
+      renderWithProviders(<MyTripsPage />);
+
+      // 데이터 로딩 후 여행 카드가 표시됨
+      await waitFor(() => {
+        expect(screen.getByText("도쿄 여행")).toBeInTheDocument();
+      });
+      expect(screen.getByText("제주 여행")).toBeInTheDocument();
+    });
+
+    it("'예정된 여행'과 '지난 여행' 섹션이 구분되어 표시된다", async () => {
+      renderWithProviders(<MyTripsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("예정된 여행")).toBeInTheDocument();
+        expect(screen.getByText("지난 여행")).toBeInTheDocument();
+      });
+
+      // 도쿄(2025-08-15 종료) → 예정된 여행
+      // 제주(2024-12-05 종료) → 지난 여행
+      expect(screen.getByText("도쿄 여행")).toBeInTheDocument();
+      expect(screen.getByText("제주 여행")).toBeInTheDocument();
+    });
+
+    it("여행이 없을 때 빈 메시지가 표시된다", async () => {
+      // 빈 배열 응답으로 오버라이드
+      server.use(
+        http.get("http://localhost:8080/travels", () => {
+          return HttpResponse.json([]);
+        })
+      );
+
+      renderWithProviders(<MyTripsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("예정된 여행이 없습니다.")).toBeInTheDocument();
+        expect(screen.getByText("지난 여행이 없습니다.")).toBeInTheDocument();
+      });
+    });
+
+    it("API 에러 시 에러 메시지와 여행 등록 버튼이 표시된다", async () => {
+      server.use(
+        http.get("http://localhost:8080/travels", () => {
+          return HttpResponse.json(
+            { message: "서버 오류" },
+            { status: 500 }
+          );
+        })
+      );
+
+      renderWithProviders(<MyTripsPage />);
+
+      // useTravelPlans 훅이 500 에러를 1회 재시도하므로 타임아웃을 넉넉하게 설정
+      await waitFor(
+        () => {
+          expect(screen.getByText("여행 일정을 불러오는데 실패했습니다.")).toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
+      expect(screen.getByText("여행 등록하기")).toBeInTheDocument();
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 유닛 테스트: 네비게이션
+  // ═══════════════════════════════════════════════════════════
+
+  describe("네비게이션", () => {
+    it("'여행 등록하기' 클릭 시 popular 페이지로 이동한다", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<MyTripsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("도쿄 여행")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("여행 등록하기"));
+
+      expect(mockPush).toHaveBeenCalledWith("my-trips/popular");
+    });
+
+    it("하단 네비게이션 '홈' 클릭 시 /home으로 이동한다", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<MyTripsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("도쿄 여행")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("홈"));
+
+      expect(mockPush).toHaveBeenCalledWith("/home");
+    });
+  });
+});

--- a/frontend/src/app/my-trips/popular/__tests__/page.test.tsx
+++ b/frontend/src/app/my-trips/popular/__tests__/page.test.tsx
@@ -1,0 +1,244 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach, beforeEach } from "vitest";
+import { renderWithProviders } from "@/test/test-utils";
+import { server } from "@/mocks/server";
+
+// ─── Next.js 모킹 ───────────────────────────────────────────
+const mockPush = vi.fn();
+const mockBack = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    back: mockBack,
+  }),
+}));
+
+vi.mock("next/image", () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => {
+    return <img {...props} alt={props.alt || ""} />;
+  },
+}));
+
+import PopularTripsPage from "../page";
+
+// ─── MSW ─────────────────────────────────────────────────────
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("PopularTripsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 통합 테스트: 데이터 로딩 & 렌더링
+  // ═══════════════════════════════════════════════════════════
+
+  describe("데이터 로딩 & 렌더링", () => {
+    it("로딩 중일 때 로딩 메시지가 표시된다", () => {
+      renderWithProviders(<PopularTripsPage />);
+      expect(screen.getByText("여행지를 불러오는 중...")).toBeInTheDocument();
+    });
+
+    it("국가 목록과 도시 목록이 정상적으로 렌더링된다", async () => {
+      renderWithProviders(<PopularTripsPage />);
+
+      // 해외 여행지 탭이 기본 → 대한민국 제외
+      // "일본"은 국가 칩(button) + 섹션 타이틀(h3) 두 곳에 렌더되므로 getAllByText 사용
+      await waitFor(() => {
+        expect(screen.getAllByText("일본").length).toBeGreaterThanOrEqual(1);
+      });
+      expect(screen.getAllByText("프랑스").length).toBeGreaterThanOrEqual(1);
+
+      // 도시 이름은 인기 여행지 행 + 도시 목록에 중복되므로 getAllByText 사용
+      expect(screen.getAllByText("도쿄").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("오사카").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("파리").length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("인기 여행지 도시들이 상단에 표시된다", async () => {
+      renderWithProviders(<PopularTripsPage />);
+
+      await waitFor(() => {
+        expect(screen.getAllByText("도쿄").length).toBeGreaterThanOrEqual(1);
+      });
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 유닛 테스트: 탭 전환
+  // ═══════════════════════════════════════════════════════════
+
+  describe("탭 전환", () => {
+    it("'국내 여행지' 탭 클릭 시 국내 도시만 표시된다", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<PopularTripsPage />);
+
+      // 데이터 로딩 대기 (해외 도시가 로드되면 준비 완료)
+      await waitFor(() => {
+        expect(screen.getAllByText("도쿄").length).toBeGreaterThanOrEqual(1);
+      });
+
+      // 국내 탭 클릭
+      await user.click(screen.getByText("국내 여행지"));
+
+      // 국내 도시가 나타나는지 확인
+      await waitFor(() => {
+        expect(screen.getAllByText("서울").length).toBeGreaterThanOrEqual(1);
+      });
+      expect(screen.getAllByText("제주").length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("'해외 여행지' 탭이 기본 활성화되어 있다", async () => {
+      renderWithProviders(<PopularTripsPage />);
+
+      // 해외 도시들이 정상 로드되면 해외 탭이 활성화된 것
+      await waitFor(() => {
+        expect(screen.getAllByText("도쿄").length).toBeGreaterThanOrEqual(1);
+      });
+
+      const overseasTab = screen.getByText("해외 여행지");
+      expect(overseasTab).toBeInTheDocument();
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 유닛 테스트: 검색
+  // ═══════════════════════════════════════════════════════════
+
+  describe("검색", () => {
+    it("검색창에 텍스트를 입력할 수 있다", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<PopularTripsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText("어디로 떠나시나요?")).toBeInTheDocument();
+      });
+
+      const input = screen.getByPlaceholderText("어디로 떠나시나요?");
+      await user.type(input, "도쿄");
+
+      expect(input).toHaveValue("도쿄");
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 유닛 테스트: 도시 선택
+  // ═══════════════════════════════════════════════════════════
+
+  describe("도시 선택", () => {
+    it("'선택' 버튼 클릭 시 하단 선택 영역이 나타난다", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<PopularTripsPage />);
+
+      await waitFor(() => {
+        expect(screen.getAllByText("선택").length).toBeGreaterThan(0);
+      });
+
+      // 첫 번째 선택 버튼 클릭
+      const selectButtons = screen.getAllByText("선택");
+      await user.click(selectButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText("선택 완료")).toBeInTheDocument();
+      });
+    });
+
+    it("선택한 도시를 해제할 수 있다 (✕ 버튼)", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<PopularTripsPage />);
+
+      await waitFor(() => {
+        expect(screen.getAllByText("선택").length).toBeGreaterThan(0);
+      });
+
+      const selectButtons = screen.getAllByText("선택");
+      await user.click(selectButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText("선택 완료")).toBeInTheDocument();
+      });
+
+      // ✕ 버튼으로 선택 해제
+      const removeBtn = screen.getByText("✕");
+      await user.click(removeBtn);
+
+      await waitFor(() => {
+        expect(screen.queryByText("선택 완료")).not.toBeInTheDocument();
+      });
+    });
+
+    it("'편집' 버튼 클릭 시 모든 선택이 해제된다", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<PopularTripsPage />);
+
+      await waitFor(() => {
+        expect(screen.getAllByText("선택").length).toBeGreaterThan(0);
+      });
+
+      const selectButtons = screen.getAllByText("선택");
+      await user.click(selectButtons[0]);
+      await user.click(selectButtons[1]);
+
+      await waitFor(() => {
+        expect(screen.getByText("편집")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("편집"));
+
+      await waitFor(() => {
+        expect(screen.queryByText("선택 완료")).not.toBeInTheDocument();
+      });
+    });
+
+    it("'선택 완료' 클릭 시 sessionStorage에 저장하고 /schedule로 이동한다", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<PopularTripsPage />);
+
+      await waitFor(() => {
+        expect(screen.getAllByText("선택").length).toBeGreaterThan(0);
+      });
+
+      const selectButtons = screen.getAllByText("선택");
+      await user.click(selectButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText("선택 완료")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("선택 완료"));
+
+      expect(mockPush).toHaveBeenCalledWith("/schedule");
+
+      const stored = sessionStorage.getItem("selectedCities");
+      expect(stored).toBeTruthy();
+      const parsed = JSON.parse(stored!);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBe(1);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 유닛 테스트: 네비게이션
+  // ═══════════════════════════════════════════════════════════
+
+  describe("네비게이션", () => {
+    it("뒤로가기 버튼 클릭 시 router.back()이 호출된다", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<PopularTripsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByAltText("뒤로")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByAltText("뒤로"));
+
+      expect(mockBack).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/app/mytripdetail/__tests__/page.test.tsx
+++ b/frontend/src/app/mytripdetail/__tests__/page.test.tsx
@@ -1,0 +1,179 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  afterAll,
+  afterEach,
+  beforeEach,
+} from "vitest";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders } from "@/test/test-utils";
+import { server } from "@/mocks/server";
+
+// ─── Next.js 모킹 ───────────────────────────────────────────
+const mockPush = vi.fn();
+const mockBack = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    back: mockBack,
+  }),
+  useSearchParams: () => ({
+    get: (key: string) => (key === "id" ? "1" : null),
+  }),
+}));
+
+vi.mock("next/image", () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => {
+    return <img {...props} alt={props.alt || ""} />;
+  },
+}));
+
+import TravelItineraryApp from "../page";
+
+// ─── MSW ─────────────────────────────────────────────────────
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("TravelItineraryApp (mytripdetail)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 통합 테스트: 여행 일정 로딩
+  // ═══════════════════════════════════════════════════════════
+
+  describe("여행 일정 로딩", () => {
+    it("로딩 중일 때 로딩 메시지가 표시된다", () => {
+      renderWithProviders(<TravelItineraryApp />);
+      expect(
+        screen.getByText("여행 일정을 불러오는 중입니다.")
+      ).toBeInTheDocument();
+    });
+
+    it("API에서 데이터를 받으면 여행 제목이 표시된다", async () => {
+      renderWithProviders(<TravelItineraryApp />);
+
+      await waitFor(() => {
+        expect(screen.getByText("도쿄 여행")).toBeInTheDocument();
+      });
+    });
+
+    it("일정 데이터가 렌더링되면 Day 섹션이 표시된다", async () => {
+      renderWithProviders(<TravelItineraryApp />);
+
+      await waitFor(() => {
+        // 2025-08-10 ~ 2025-08-12 = 3일
+        expect(screen.getByText(/Day 1/)).toBeInTheDocument();
+      });
+    });
+
+    it("장소 이름(도쿄 타워)이 일정에 표시된다", async () => {
+      renderWithProviders(<TravelItineraryApp />);
+
+      await waitFor(() => {
+        expect(screen.getByText("도쿄 타워")).toBeInTheDocument();
+      });
+    });
+
+    it("메모가 있으면 메모 내용이 표시된다", async () => {
+      renderWithProviders(<TravelItineraryApp />);
+
+      await waitFor(() => {
+        expect(screen.getByText("첫째 날 메모")).toBeInTheDocument();
+      });
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 통합 테스트: API 에러
+  // ═══════════════════════════════════════════════════════════
+
+  describe("API 에러", () => {
+    it("API 실패 시 에러 메시지가 표시된다", async () => {
+      server.use(
+        http.get("http://localhost:8080/travels/:id", () => {
+          return HttpResponse.json(
+            { message: "서버 오류" },
+            { status: 500 }
+          );
+        })
+      );
+
+      renderWithProviders(<TravelItineraryApp />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("일정을 불러오는데 실패했습니다.")
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("에러 시 '내 여행으로' 버튼이 있고 클릭하면 /my-trips로 이동한다", async () => {
+      const user = userEvent.setup();
+
+      server.use(
+        http.get("http://localhost:8080/travels/:id", () => {
+          return HttpResponse.json(
+            { message: "서버 오류" },
+            { status: 500 }
+          );
+        })
+      );
+
+      renderWithProviders(<TravelItineraryApp />);
+
+      await waitFor(() => {
+        expect(screen.getByText("내 여행으로")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("내 여행으로"));
+      expect(mockPush).toHaveBeenCalledWith("/my-trips");
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 유닛 테스트: 탭 & 버튼
+  // ═══════════════════════════════════════════════════════════
+
+  describe("탭 & 버튼", () => {
+    it("'전체 경로 최적화' 탭이 기본 선택되어 있다", async () => {
+      renderWithProviders(<TravelItineraryApp />);
+
+      await waitFor(() => {
+        expect(screen.getByText("전체 경로 최적화")).toBeInTheDocument();
+      });
+    });
+
+    it("'+ 일행 추가' 탭 클릭 시 invite 페이지로 이동한다", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<TravelItineraryApp />);
+
+      await waitFor(() => {
+        expect(screen.getByText("+ 일행 추가")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("+ 일행 추가"));
+      expect(mockPush).toHaveBeenCalledWith("/mytripdetail/invite?id=1");
+    });
+
+    it("'메모 추가' 버튼이 표시된다", async () => {
+      renderWithProviders(<TravelItineraryApp />);
+
+      await waitFor(() => {
+        expect(
+          screen.getAllByText("메모 추가").length
+        ).toBeGreaterThanOrEqual(1);
+      });
+    });
+  });
+});

--- a/frontend/src/app/optimize/check-result/__tests__/page.test.tsx
+++ b/frontend/src/app/optimize/check-result/__tests__/page.test.tsx
@@ -1,0 +1,297 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  afterAll,
+  afterEach,
+  beforeEach,
+} from "vitest";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders } from "@/test/test-utils";
+import { server } from "@/mocks/server";
+
+// ─── Google Maps 컴포넌트 모킹 (jsdom에서 동작 불가) ─────────
+vi.mock("../../result/components/RouteMapComponent", () => ({
+  default: () => <div data-testid="mock-route-map">Mock Route Map</div>,
+}));
+
+// ─── Next.js 모킹 ───────────────────────────────────────────
+const mockPush = vi.fn();
+const mockBack = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    back: mockBack,
+  }),
+}));
+
+vi.mock("next/image", () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => {
+    return <img {...props} alt={props.alt || ""} />;
+  },
+}));
+
+import CheckResultPage from "../page";
+
+// ─── 테스트용 Storage 데이터 ─────────────────────────────────
+const TEST_DATES = [
+  new Date("2025-09-01").toISOString(),
+  new Date("2025-09-02").toISOString(),
+];
+
+const TEST_PLACES = [
+  {
+    name: "센소지",
+    address: "2 Chome-3-1 Asakusa",
+    latitude: 35.7148,
+    longitude: 139.7967,
+    rating: 4.5,
+    reviewCount: 1200,
+    types: ["tourist_attraction"],
+    photoReference: null,
+  },
+  {
+    name: "도쿄 타워",
+    address: "4 Chome-2-8 Shibakoen",
+    latitude: 35.6586,
+    longitude: 139.7454,
+    rating: 4.3,
+    reviewCount: 800,
+    types: ["tourist_attraction"],
+    photoReference: null,
+  },
+];
+
+const TEST_CITIES = [{ cityId: 10, countryId: 1, name: "도쿄" }];
+
+const TEST_TRAVEL_TIMES = [
+  {
+    date: new Date("2025-09-01").toISOString(),
+    startAm: true,
+    startHour: 9,
+    startMin: 0,
+    endAm: false,
+    endHour: 6,
+    endMin: 0,
+  },
+  {
+    date: new Date("2025-09-02").toISOString(),
+    startAm: true,
+    startHour: 10,
+    startMin: 0,
+    endAm: false,
+    endHour: 5,
+    endMin: 0,
+  },
+];
+
+function setupTestStorage() {
+  localStorage.setItem("selectedTravelDates", JSON.stringify(TEST_DATES));
+  localStorage.setItem("selectedTravelTimes", JSON.stringify(TEST_TRAVEL_TIMES));
+  sessionStorage.setItem("selectedPlaces", JSON.stringify(TEST_PLACES));
+  sessionStorage.setItem("selectedCities", JSON.stringify(TEST_CITIES));
+}
+
+// ─── MSW ─────────────────────────────────────────────────────
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("CheckResultPage (optimize/check-result)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+    // window.alert 모킹 (jsdom에서는 동작하지만 테스트에서 확인하기 위해)
+    vi.spyOn(window, "alert").mockImplementation(() => {});
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 유닛 테스트: 기본 렌더링
+  // ═══════════════════════════════════════════════════════════
+
+  describe("기본 렌더링", () => {
+    it("Storage 데이터가 있으면 여행 제목이 표시된다", async () => {
+      setupTestStorage();
+      renderWithProviders(<CheckResultPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("도쿄 여행")).toBeInTheDocument();
+      });
+    });
+
+    it("장소들이 Day별로 분배되어 표시된다", async () => {
+      setupTestStorage();
+      renderWithProviders(<CheckResultPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("센소지")).toBeInTheDocument();
+        expect(screen.getByText("도쿄 타워")).toBeInTheDocument();
+      });
+    });
+
+    it("Day 섹션이 날짜 수만큼 표시된다", async () => {
+      setupTestStorage();
+      renderWithProviders(<CheckResultPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Day 1/)).toBeInTheDocument();
+        expect(screen.getByText(/Day 2/)).toBeInTheDocument();
+      });
+    });
+
+    it("'수정하기'와 '일정 등록하기' 버튼이 표시된다", async () => {
+      setupTestStorage();
+      renderWithProviders(<CheckResultPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("수정하기")).toBeInTheDocument();
+        expect(screen.getByText("일정 등록하기")).toBeInTheDocument();
+      });
+    });
+
+    it("Google Maps 대신 mock 컴포넌트가 렌더링된다", async () => {
+      setupTestStorage();
+      renderWithProviders(<CheckResultPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("mock-route-map")).toBeInTheDocument();
+      });
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 유닛 테스트: 편집 모드
+  // ═══════════════════════════════════════════════════════════
+
+  describe("편집 모드", () => {
+    it("'수정하기' 클릭 시 편집 모드로 전환된다", async () => {
+      setupTestStorage();
+      const user = userEvent.setup();
+      renderWithProviders(<CheckResultPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("수정하기")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("수정하기"));
+
+      // 편집 모드에서는 '완료' 버튼 2개 (헤더 + 하단)와 '선택 삭제' 버튼이 표시
+      await waitFor(() => {
+        expect(screen.getByText("선택 삭제")).toBeInTheDocument();
+      });
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 유닛 테스트: 취소 모달
+  // ═══════════════════════════════════════════════════════════
+
+  describe("취소 모달", () => {
+    it("'취소' 클릭 시 확인 모달이 표시된다", async () => {
+      setupTestStorage();
+      const user = userEvent.setup();
+      renderWithProviders(<CheckResultPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("취소")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("취소"));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("모든 내용을 삭제할까요?")
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("모달에서 '확인' 클릭 시 router.back()이 호출된다", async () => {
+      setupTestStorage();
+      const user = userEvent.setup();
+      renderWithProviders(<CheckResultPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("취소")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("취소"));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("모든 내용을 삭제할까요?")
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("확인"));
+      expect(mockBack).toHaveBeenCalled();
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 통합 테스트: 일정 등록 API
+  // ═══════════════════════════════════════════════════════════
+
+  describe("일정 등록 API", () => {
+    it("'일정 등록하기' 클릭 시 API 호출 후 성공 alert이 뜨고 /my-trips로 이동한다", async () => {
+      setupTestStorage();
+      const user = userEvent.setup();
+      renderWithProviders(<CheckResultPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("일정 등록하기")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("일정 등록하기"));
+
+      // API 호출 완료 후 (MSW가 즉시 응답하므로 "등록 중..."은 순간 표시됨)
+      await waitFor(
+        () => {
+          expect(window.alert).toHaveBeenCalledWith(
+            "여행 일정이 등록되었습니다!"
+          );
+        },
+        { timeout: 5000 }
+      );
+
+      expect(mockPush).toHaveBeenCalledWith("/my-trips");
+    });
+
+    it("API 실패 시 에러 alert이 표시된다", async () => {
+      // 여행 계획 생성 API를 실패로 오버라이드
+      server.use(
+        http.post("http://localhost:8080/travels", () => {
+          return HttpResponse.json(
+            { message: "서버 오류" },
+            { status: 500 }
+          );
+        })
+      );
+
+      setupTestStorage();
+      const user = userEvent.setup();
+      renderWithProviders(<CheckResultPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("일정 등록하기")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("일정 등록하기"));
+
+      await waitFor(
+        () => {
+          expect(window.alert).toHaveBeenCalled();
+          // 에러 메시지가 포함된 alert
+          const alertCall = (window.alert as any).mock.calls[0][0] as string;
+          expect(alertCall).toContain("실패");
+        },
+        { timeout: 5000 }
+      );
+    });
+  });
+});

--- a/frontend/src/app/optimize/places/__tests__/page.test.tsx
+++ b/frontend/src/app/optimize/places/__tests__/page.test.tsx
@@ -1,0 +1,225 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+} from "vitest";
+import { renderWithProviders } from "@/test/test-utils";
+
+// ─── Google Maps 컴포넌트 모킹 (dynamic import) ──────────────
+vi.mock("next/dynamic", () => ({
+  default: () => {
+    // dynamic()이 반환하는 컴포넌트를 모킹
+    const MockComponent = () => (
+      <div data-testid="mock-google-map">Mock Google Map</div>
+    );
+    MockComponent.displayName = "MockGoogleMapComponent";
+    return MockComponent;
+  },
+}));
+
+// ─── LocationSearchInput 모킹 (Google Places 의존) ──────────
+vi.mock("../../../my-trips/map/components/LocationSearchInput", () => ({
+  default: ({ onSelect, onClear, onSearchStart }: any) => (
+    <div data-testid="mock-search-input">
+      <input
+        placeholder="장소 검색"
+        onChange={() => onSearchStart?.()}
+        data-testid="search-input"
+      />
+      <button
+        data-testid="select-place-btn"
+        onClick={() =>
+          onSelect?.({
+            name: "시부야 스크램블",
+            address: "1 Chome Shibuya",
+            latitude: 35.6595,
+            longitude: 139.7004,
+            rating: 4.2,
+            reviewCount: 500,
+            types: ["tourist_attraction"],
+            photoReference: null,
+          })
+        }
+      >
+        장소 선택
+      </button>
+      <button data-testid="clear-btn" onClick={() => onClear?.()}>
+        초기화
+      </button>
+    </div>
+  ),
+}));
+
+// ─── Loading 컴포넌트 모킹 ──────────────────────────────────
+vi.mock("../../components/Loading", () => ({
+  default: () => <div data-testid="loading">로딩 중...</div>,
+}));
+
+// ─── Next.js 모킹 ───────────────────────────────────────────
+const mockPush = vi.fn();
+const mockBack = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    back: mockBack,
+  }),
+}));
+
+import PlacesPage from "../page";
+
+// ─── 테스트용 Storage 데이터 ─────────────────────────────────
+const TEST_EXISTING_PLACES = [
+  {
+    name: "센소지",
+    address: "2 Chome-3-1 Asakusa",
+    latitude: 35.7148,
+    longitude: 139.7967,
+    rating: 4.5,
+    reviewCount: 1200,
+    types: ["tourist_attraction"],
+    photoReference: null,
+    image: "/icons/blank.png",
+  },
+];
+
+const TEST_CITIES = [{ cityId: 10, countryId: 1, name: "도쿄" }];
+
+function setupTestStorage() {
+  sessionStorage.setItem("selectedPlaces", JSON.stringify(TEST_EXISTING_PLACES));
+  sessionStorage.setItem("selectedCities", JSON.stringify(TEST_CITIES));
+}
+
+describe("PlacesPage (optimize/places)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 기본 렌더링
+  // ═══════════════════════════════════════════════════════════
+
+  it("헤더에 '가고싶은 장소 추가' 텍스트가 표시된다", async () => {
+    renderWithProviders(<PlacesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("가고싶은 장소 추가")).toBeInTheDocument();
+    });
+  });
+
+  it("검색 입력이 표시된다", async () => {
+    renderWithProviders(<PlacesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-search-input")).toBeInTheDocument();
+    });
+  });
+
+  it("Google Maps 대신 mock 컴포넌트가 렌더링된다", async () => {
+    renderWithProviders(<PlacesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-google-map")).toBeInTheDocument();
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // sessionStorage에서 기존 장소 로드
+  // ═══════════════════════════════════════════════════════════
+
+  it("sessionStorage에 장소가 있으면 기존 장소 목록이 표시된다", async () => {
+    setupTestStorage();
+    renderWithProviders(<PlacesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("장소 1")).toBeInTheDocument();
+    });
+  });
+
+  it("기존 장소가 있으면 '추천 경로 만들기' 버튼이 표시된다", async () => {
+    setupTestStorage();
+    renderWithProviders(<PlacesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("추천 경로 만들기")).toBeInTheDocument();
+    });
+  });
+
+  it("장소가 없으면 '추가' 버튼이 표시된다", async () => {
+    renderWithProviders(<PlacesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("추가")).toBeInTheDocument();
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 장소 추가/삭제
+  // ═══════════════════════════════════════════════════════════
+
+  it("검색에서 장소를 선택하면 목록에 추가된다", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<PlacesPage />);
+
+    // 장소 선택 버튼 클릭 (모킹된 LocationSearchInput에서)
+    await user.click(screen.getByTestId("select-place-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByText("장소 1")).toBeInTheDocument();
+    });
+
+    // sessionStorage에도 저장되었는지 확인
+    const stored = JSON.parse(sessionStorage.getItem("selectedPlaces") || "[]");
+    expect(stored).toHaveLength(1);
+    expect(stored[0].name).toBe("시부야 스크램블");
+  });
+
+  it("삭제 버튼 클릭 시 장소가 제거된다", async () => {
+    setupTestStorage();
+    const user = userEvent.setup();
+    renderWithProviders(<PlacesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("장소 1")).toBeInTheDocument();
+    });
+
+    // 삭제 버튼(✕) 클릭
+    await user.click(screen.getByText("✕"));
+
+    await waitFor(() => {
+      expect(screen.queryByText("장소 1")).not.toBeInTheDocument();
+    });
+
+    // sessionStorage도 업데이트됨
+    const stored = JSON.parse(sessionStorage.getItem("selectedPlaces") || "[]");
+    expect(stored).toHaveLength(0);
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 네비게이션
+  // ═══════════════════════════════════════════════════════════
+
+  it("'추천 경로 만들기' 클릭 시 로딩 화면이 표시된다", async () => {
+    setupTestStorage();
+    const user = userEvent.setup();
+    renderWithProviders(<PlacesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("추천 경로 만들기")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("추천 경로 만들기"));
+
+    // 로딩 화면 표시 (setTimeout 내부에서 router.push가 3초 후 호출됨)
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/app/optimize/result/__tests__/page.test.tsx
+++ b/frontend/src/app/optimize/result/__tests__/page.test.tsx
@@ -1,0 +1,211 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+} from "vitest";
+import { renderWithProviders } from "@/test/test-utils";
+
+// ─── Google Maps 컴포넌트 모킹 ─────────────────────────────
+vi.mock("../components/RouteMapComponent", () => ({
+  default: (props: any) => (
+    <div data-testid="mock-route-map">
+      {props.places?.map((p: any, i: number) => (
+        <span key={i} data-testid={`map-place-${i}`}>
+          {p.name}
+        </span>
+      ))}
+    </div>
+  ),
+}));
+
+// ─── Next.js 모킹 ───────────────────────────────────────────
+const mockPush = vi.fn();
+const mockBack = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    back: mockBack,
+  }),
+}));
+
+vi.mock("next/image", () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => {
+    return <img {...props} alt={props.alt || ""} />;
+  },
+}));
+
+import ResultPage from "../page";
+
+// ─── 테스트용 Storage 데이터 ─────────────────────────────────
+const TEST_DATES = [
+  new Date("2025-09-01").toISOString(),
+  new Date("2025-09-02").toISOString(),
+];
+
+const TEST_PLACES = [
+  {
+    name: "센소지",
+    address: "2 Chome-3-1 Asakusa",
+    latitude: 35.7148,
+    longitude: 139.7967,
+    rating: 4.5,
+    reviewCount: 1200,
+    types: ["tourist_attraction"],
+    photoReference: null,
+  },
+  {
+    name: "도쿄 타워",
+    address: "4 Chome-2-8 Shibakoen",
+    latitude: 35.6586,
+    longitude: 139.7454,
+    rating: 4.3,
+    reviewCount: 800,
+    types: ["tourist_attraction"],
+    photoReference: null,
+  },
+];
+
+const TEST_TRAVEL_TIMES = [
+  {
+    date: new Date("2025-09-01").toISOString(),
+    startAm: true,
+    startHour: 9,
+    startMin: 0,
+    endAm: false,
+    endHour: 6,
+    endMin: 0,
+  },
+];
+
+function setupTestStorage() {
+  localStorage.setItem("selectedTravelDates", JSON.stringify(TEST_DATES));
+  localStorage.setItem("selectedTravelTimes", JSON.stringify(TEST_TRAVEL_TIMES));
+  sessionStorage.setItem("selectedPlaces", JSON.stringify(TEST_PLACES));
+}
+
+describe("ResultPage (optimize/result)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 기본 렌더링
+  // ═══════════════════════════════════════════════════════════
+
+  it("Day 1 헤더가 표시된다", async () => {
+    setupTestStorage();
+    renderWithProviders(<ResultPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Day 1")).toBeInTheDocument();
+    });
+  });
+
+  it("Storage 데이터에서 장소가 로드되어 하단 패널에 첫 번째 장소가 표시된다", async () => {
+    setupTestStorage();
+    renderWithProviders(<ResultPage />);
+
+    // "센소지"가 mock 지도와 하단 패널 두 곳에 표시되므로 getAllByText 사용
+    await waitFor(() => {
+      expect(screen.getAllByText("센소지").length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("Google Maps 대신 mock 컴포넌트가 렌더링된다", async () => {
+    setupTestStorage();
+    renderWithProviders(<ResultPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-route-map")).toBeInTheDocument();
+    });
+  });
+
+  it("장소의 테마(카테고리)가 표시된다", async () => {
+    setupTestStorage();
+    renderWithProviders(<ResultPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/관광명소/)).toBeInTheDocument();
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // Day 전환
+  // ═══════════════════════════════════════════════════════════
+
+  it("'다음 날짜' 버튼 클릭 시 Day 2로 전환된다", async () => {
+    setupTestStorage();
+    const user = userEvent.setup();
+    renderWithProviders(<ResultPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Day 1")).toBeInTheDocument();
+    });
+
+    // aria-label로 다음 날짜 버튼 찾기
+    const nextBtn = screen.getByLabelText("다음 날짜");
+    await user.click(nextBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Day 2")).toBeInTheDocument();
+    });
+  });
+
+  it("Day 1에서 '이전 날짜' 버튼을 누르면 Day 1에 머문다", async () => {
+    setupTestStorage();
+    const user = userEvent.setup();
+    renderWithProviders(<ResultPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Day 1")).toBeInTheDocument();
+    });
+
+    const prevBtn = screen.getByLabelText("이전 날짜");
+    await user.click(prevBtn);
+
+    // 여전히 Day 1
+    expect(screen.getByText("Day 1")).toBeInTheDocument();
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 네비게이션
+  // ═══════════════════════════════════════════════════════════
+
+  it("'다음' 버튼 클릭 시 /optimize/check-result로 이동한다", async () => {
+    setupTestStorage();
+    const user = userEvent.setup();
+    renderWithProviders(<ResultPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("다음")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("다음"));
+    expect(mockPush).toHaveBeenCalledWith("/optimize/check-result");
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // Storage 없을 때
+  // ═══════════════════════════════════════════════════════════
+
+  it("Storage 데이터가 없으면 장소가 표시되지 않는다", async () => {
+    // localStorage/sessionStorage를 비운 채로 렌더링
+    renderWithProviders(<ResultPage />);
+
+    // mock-route-map은 존재하지만 장소는 없음
+    await waitFor(() => {
+      expect(screen.getByTestId("mock-route-map")).toBeInTheDocument();
+    });
+
+    // 장소 이름이 없어야 함
+    expect(screen.queryByText("센소지")).not.toBeInTheDocument();
+    expect(screen.queryByText("도쿄 타워")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/optimize/route/__tests__/page.test.tsx
+++ b/frontend/src/app/optimize/route/__tests__/page.test.tsx
@@ -1,0 +1,120 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+
+// ─── Next.js 모킹 ───────────────────────────────────────────
+const mockPush = vi.fn();
+const mockBack = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    back: mockBack,
+  }),
+  useSearchParams: () => ({
+    get: () => null,
+  }),
+}));
+
+vi.mock("next/image", () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => {
+    return <img {...props} alt={props.alt || ""} />;
+  },
+}));
+
+import RouteOptimizePage from "../page";
+
+describe("RouteOptimizePage (optimize/route)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 유닛 테스트: 기본 렌더링
+  // ═══════════════════════════════════════════════════════════
+
+  describe("기본 렌더링", () => {
+    it("'전체 경로 최적화' 제목이 표시된다", () => {
+      render(<RouteOptimizePage />);
+      expect(screen.getByText("전체 경로 최적화")).toBeInTheDocument();
+    });
+
+    it("localStorage에 날짜가 없으면 기본 3일이 표시된다", () => {
+      render(<RouteOptimizePage />);
+      expect(screen.getByText(/Day 1/)).toBeInTheDocument();
+      expect(screen.getByText(/Day 2/)).toBeInTheDocument();
+      expect(screen.getByText(/Day 3/)).toBeInTheDocument();
+    });
+
+    it("AM/PM 토글이 각 Day마다 표시된다", () => {
+      render(<RouteOptimizePage />);
+      // 각 Day에 출발/도착 2개씩 AM이 있으므로 최소 3*2=6개
+      expect(screen.getAllByText("AM").length).toBeGreaterThanOrEqual(6);
+      expect(screen.getAllByText("PM").length).toBeGreaterThanOrEqual(6);
+    });
+
+    it("'여행 출발 시간'과 '여행 도착 시간' 라벨이 표시된다", () => {
+      render(<RouteOptimizePage />);
+      expect(
+        screen.getAllByText("여행 출발 시간").length
+      ).toBeGreaterThanOrEqual(1);
+      expect(
+        screen.getAllByText("여행 도착 시간").length
+      ).toBeGreaterThanOrEqual(1);
+    });
+
+    it("'다음' 버튼이 표시된다", () => {
+      render(<RouteOptimizePage />);
+      expect(screen.getByText("다음")).toBeInTheDocument();
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 유닛 테스트: localStorage에서 날짜 로드
+  // ═══════════════════════════════════════════════════════════
+
+  describe("localStorage 날짜 로드", () => {
+    it("localStorage에 2일짜리 날짜가 있으면 Day 2개만 표시된다", () => {
+      const dates = [
+        new Date("2025-09-01").toISOString(),
+        new Date("2025-09-02").toISOString(),
+      ];
+      localStorage.setItem("selectedTravelDates", JSON.stringify(dates));
+
+      render(<RouteOptimizePage />);
+      expect(screen.getByText(/Day 1/)).toBeInTheDocument();
+      expect(screen.getByText(/Day 2/)).toBeInTheDocument();
+      expect(screen.queryByText(/Day 3/)).not.toBeInTheDocument();
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 유닛 테스트: 네비게이션
+  // ═══════════════════════════════════════════════════════════
+
+  describe("네비게이션", () => {
+    it("뒤로가기 버튼 클릭 시 router.back()이 호출된다", async () => {
+      const user = userEvent.setup();
+      render(<RouteOptimizePage />);
+
+      const backBtn = screen.getByLabelText("뒤로");
+      await user.click(backBtn);
+
+      expect(mockBack).toHaveBeenCalled();
+    });
+
+    it("'다음' 버튼 클릭 시 localStorage에 저장하고 /optimize/places로 이동한다", async () => {
+      const user = userEvent.setup();
+      render(<RouteOptimizePage />);
+
+      await user.click(screen.getByText("다음"));
+
+      expect(mockPush).toHaveBeenCalledWith("/optimize/places");
+      const stored = localStorage.getItem("selectedTravelTimes");
+      expect(stored).toBeTruthy();
+    });
+  });
+});

--- a/frontend/src/app/schedule/__tests__/page.test.tsx
+++ b/frontend/src/app/schedule/__tests__/page.test.tsx
@@ -1,0 +1,192 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+
+// ─── Next.js 모킹 ───────────────────────────────────────────
+const mockPush = vi.fn();
+const mockBack = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    back: mockBack,
+  }),
+}));
+
+// schedule 페이지의 스타일 모듈 모킹
+vi.mock("../stlyes", () => {
+  // styled-components를 흉내내는 프록시: 어떤 프로퍼티든 태그를 반환
+  const createTag =
+    (tag: string) =>
+    ({ children, ...rest }: any) => {
+      // boolean transient props ($로 시작) 제거
+      const filtered: Record<string, any> = {};
+      for (const [k, v] of Object.entries(rest)) {
+        if (!k.startsWith("$")) filtered[k] = v;
+      }
+      const el = document.createElement(tag);
+      return <div data-testid={tag} {...filtered}>{children}</div>;
+    };
+
+  return {
+    Container: createTag("Container"),
+    Header: createTag("Header"),
+    HeaderContent: createTag("HeaderContent"),
+    BackButton: ({ children, ...rest }: any) => (
+      <button data-testid="back-button" {...rest}>
+        {children}
+      </button>
+    ),
+    Title: createTag("Title"),
+    Spacer: createTag("Spacer"),
+    ScrollableArea: createTag("ScrollableArea"),
+    CalendarContainer: createTag("CalendarContainer"),
+    MonthSection: createTag("MonthSection"),
+    MonthHeader: createTag("MonthHeader"),
+    MonthTitle: createTag("MonthTitle"),
+    WeekDaysGrid: createTag("WeekDaysGrid"),
+    WeekDayCell: createTag("WeekDayCell"),
+    WeekDayText: ({ children, ...rest }: any) => {
+      const { $dayIndex, ...filtered } = rest;
+      return <span {...filtered}>{children}</span>;
+    },
+    DatesGrid: createTag("DatesGrid"),
+    DateButtonStyled: ({ children, onClick, disabled, ...rest }: any) => {
+      const { $isSelected, $isWeekend, $isSelectable, ...filtered } = rest;
+      return (
+        <button
+          onClick={onClick}
+          disabled={disabled}
+          data-selected={$isSelected}
+          {...filtered}
+        >
+          {children}
+        </button>
+      );
+    },
+    DateNumber: ({ children }: any) => <span>{children}</span>,
+    PulseEffect: () => <span data-testid="pulse" />,
+    EmptyCell: () => <div data-testid="empty-cell" />,
+    BottomFixedContainer: createTag("BottomFixedContainer"),
+    CompleteButton: ({ children, onClick, disabled, ...rest }: any) => {
+      const { $hasSelections, ...filtered } = rest;
+      return (
+        <button onClick={onClick} disabled={disabled} {...filtered}>
+          {children}
+        </button>
+      );
+    },
+  };
+});
+
+import TravelDatePicker from "../page";
+
+describe("TravelDatePicker (schedule)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 유닛 테스트: 기본 렌더링
+  // ═══════════════════════════════════════════════════════════
+
+  describe("기본 렌더링", () => {
+    it("'여행 날짜 선택' 제목이 표시된다", () => {
+      render(<TravelDatePicker />);
+      expect(screen.getByText("여행 날짜 선택")).toBeInTheDocument();
+    });
+
+    it("날짜를 선택하지 않았을 때 '날짜를 선택해주세요' 버튼이 표시된다", () => {
+      render(<TravelDatePicker />);
+      expect(screen.getByText("날짜를 선택해주세요")).toBeInTheDocument();
+    });
+
+    it("현재 월이 표시된다", () => {
+      render(<TravelDatePicker />);
+      const now = new Date();
+      const monthLabel = `${now.getFullYear()}년 ${String(
+        now.getMonth() + 1
+      ).padStart(2, "0")}월`;
+      expect(screen.getByText(monthLabel)).toBeInTheDocument();
+    });
+
+    it("요일 헤더(S M T W T F S)가 표시된다", () => {
+      render(<TravelDatePicker />);
+      // 요일이 여러 달에 걸쳐 반복 렌더링됨 → getAllByText
+      expect(screen.getAllByText("S").length).toBeGreaterThanOrEqual(2);
+      expect(screen.getAllByText("M").length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 유닛 테스트: 날짜 선택
+  // ═══════════════════════════════════════════════════════════
+
+  describe("날짜 선택", () => {
+    it("날짜를 클릭하면 '선택 완료' 버튼이 나타난다", async () => {
+      const user = userEvent.setup();
+      render(<TravelDatePicker />);
+
+      // 현재 월의 15일 클릭 (대부분의 달에 15일이 존재)
+      const day15Buttons = screen.getAllByText("15");
+      await user.click(day15Buttons[0]);
+
+      expect(screen.getByText("선택 완료")).toBeInTheDocument();
+    });
+
+    it("날짜를 선택하지 않으면 하단 버튼이 비활성화된다", () => {
+      render(<TravelDatePicker />);
+      const btn = screen.getByText("날짜를 선택해주세요");
+      expect(btn).toBeDisabled();
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  // 유닛 테스트: 네비게이션
+  // ═══════════════════════════════════════════════════════════
+
+  describe("네비게이션", () => {
+    it("뒤로가기 버튼 클릭 시 router.back()이 호출된다", async () => {
+      const user = userEvent.setup();
+      render(<TravelDatePicker />);
+
+      const backBtn = screen.getByTestId("back-button");
+      await user.click(backBtn);
+
+      expect(mockBack).toHaveBeenCalled();
+    });
+
+    it("날짜 선택 후 '선택 완료' 클릭 시 /my-trips/map으로 이동한다", async () => {
+      const user = userEvent.setup();
+      render(<TravelDatePicker />);
+
+      // 날짜 선택
+      const day15Buttons = screen.getAllByText("15");
+      await user.click(day15Buttons[0]);
+
+      // 선택 완료 클릭
+      await user.click(screen.getByText("선택 완료"));
+
+      expect(mockPush).toHaveBeenCalledWith("/my-trips/map");
+    });
+
+    it("'선택 완료' 클릭 시 localStorage에 날짜가 저장된다", async () => {
+      const user = userEvent.setup();
+      render(<TravelDatePicker />);
+
+      const day15Buttons = screen.getAllByText("15");
+      await user.click(day15Buttons[0]);
+
+      await user.click(screen.getByText("선택 완료"));
+
+      const stored = localStorage.getItem("selectedTravelDates");
+      expect(stored).toBeTruthy();
+      const dates = JSON.parse(stored!);
+      expect(Array.isArray(dates)).toBe(true);
+      expect(dates.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -82,4 +82,135 @@ export const handlers = [
       { status: 400 }
     );
   }),
+
+  // ─── 여행 계획 목록 조회 ────────────────────────────────────
+  http.get(`${BASE_URL}/travels`, () => {
+    return HttpResponse.json([
+      {
+        travelPlanId: 1,
+        startDate: "2025-08-10",
+        endDate: "2025-08-15",
+        countryName: "일본",
+        cityName: "도쿄",
+      },
+      {
+        travelPlanId: 2,
+        startDate: "2024-12-01",
+        endDate: "2024-12-05",
+        countryName: "대한민국",
+        cityName: "제주",
+      },
+    ]);
+  }),
+
+  // ─── 국가 검색 ─────────────────────────────────────────────
+  http.get(`${BASE_URL}/countries`, () => {
+    return HttpResponse.json([
+      { countryId: 1, koreanName: "일본", englishName: "Japan" },
+      { countryId: 2, koreanName: "프랑스", englishName: "France" },
+      { countryId: 3, koreanName: "대한민국", englishName: "South Korea" },
+    ]);
+  }),
+
+  // ─── 여행 계획 단건 조회 ────────────────────────────────────
+  http.get(`${BASE_URL}/travels/:id`, ({ params }) => {
+    const id = Number(params.id);
+    return HttpResponse.json({
+      travelPlanId: id,
+      startDate: "2025-08-10",
+      endDate: "2025-08-12",
+      countryName: "일본",
+      cityName: "도쿄",
+      daySchedules: [
+        {
+          dayScheduleId: 100,
+          date: "2025-08-10",
+          startTime: "09:00:00",
+          finishTime: "18:00:00",
+          dayScheduleMemo: "첫째 날 메모",
+          schedules: [
+            {
+              scheduleOrder: 1,
+              preferTime: "Morning",
+              locationName: "도쿄 타워",
+              location: {
+                place: "도쿄 타워",
+                name: "도쿄 타워",
+                latitude: 35.6586,
+                longitude: 139.7454,
+                address: "4 Chome-2-8 Shibakoen",
+                category: "관광명소",
+              },
+            },
+          ],
+        },
+      ],
+    });
+  }),
+
+  // ─── 장소 목록 조회 ─────────────────────────────────────────
+  http.get(`${BASE_URL}/locations/getLocations/:id`, () => {
+    return HttpResponse.json([
+      {
+        locationId: 1,
+        place: "도쿄 타워",
+        latitude: 35.6586,
+        longitude: 139.7454,
+        address: "4 Chome-2-8 Shibakoen",
+        category: "관광명소",
+      },
+    ]);
+  }),
+
+  // ─── 도시 검색 ─────────────────────────────────────────────
+  http.get(`${BASE_URL}/cities`, ({ request }) => {
+    const url = new URL(request.url);
+    const countryId = url.searchParams.get("countryId");
+
+    const allCities = [
+      { cityId: 10, countryId: 1, korean: "도쿄", english: "Tokyo" },
+      { cityId: 11, countryId: 1, korean: "오사카", english: "Osaka" },
+      { cityId: 20, countryId: 2, korean: "파리", english: "Paris" },
+      { cityId: 21, countryId: 2, korean: "바르셀로나", english: "Barcelona" },
+      { cityId: 30, countryId: 3, korean: "서울", english: "Seoul" },
+      { cityId: 31, countryId: 3, korean: "제주", english: "Jeju" },
+    ];
+
+    if (countryId) {
+      return HttpResponse.json(
+        allCities.filter((c) => c.countryId === Number(countryId))
+      );
+    }
+    return HttpResponse.json(allCities);
+  }),
+
+  // ─── 여행 계획 생성 ─────────────────────────────────────────
+  http.post(`${BASE_URL}/travels`, async () => {
+    return HttpResponse.json({
+      travelPlanId: 99,
+      startDate: "2025-09-01",
+      endDate: "2025-09-03",
+      countryName: "일본",
+      cityName: "도쿄",
+    });
+  }),
+
+  // ─── 장소 저장 ─────────────────────────────────────────────
+  http.post(`${BASE_URL}/locations`, async () => {
+    return HttpResponse.json([
+      {
+        locationId: 10,
+        place: "센소지",
+        latitude: 35.7148,
+        longitude: 139.7967,
+        address: "2 Chome-3-1 Asakusa",
+        category: "ATTRACTION",
+      },
+    ]);
+  }),
+
+  // ─── 일정 생성 ─────────────────────────────────────────────
+  http.post(`${BASE_URL}/daySchedule/create/:travelPlanId`, async () => {
+    return HttpResponse.json("일정이 생성되었습니다.");
+  }),
 ];


### PR DESCRIPTION
Phase | 대상 | 테스트 수 | 테스트 내용
-- | -- | -- | --
Phase 1 | 테스트 환경 구축 (설정 파일) | - | vitest.config.ts, test-utils.tsx, MSW server/handlers 세팅
Phase 2 | mytripdetail/invite | 10개 | 
Phase 3 | auth/login | 9개 (유닛5 + 통합4) | 렌더링, 이메일 유효성, 버튼 활성화, 로그인 성공/실패(MSW), 서버에러, 로딩 텍스트
  | auth/register | 12개 (유닛9 + 통합3) | 약관 전체동의/해제/개별체크, Step 전환, 비밀번호 조건/불일치, 회원가입 성공(MSW), 중복 이메일/닉네임 에러
  | auth/verify | 9개 (유닛) | 렌더링, 자동 인증코드 발송, 자동 포커스, 6자리 입력, 버튼 활성화/비활성화, 인증 호출, 실패 시 초기화, 재발송
Phase 4 | my-trips | 7개 (유닛2 + 통합5) | 로딩 메시지, 여행 목록 렌더링(MSW), 예정/지난 여행 구분, 빈 목록, API 에러, 네비게이션
  | my-trips/popular | 11개 (유닛8 + 통합3) | 국가/도시 로드(MSW), 인기 여행지, 국내/해외 탭 전환, 검색 입력, 도시 선택/해제/편집, sessionStorage 저장, 네비게이션
Phase 5 | mytripdetail | 10개 (유닛3 + 통합7) | 로딩, 여행 제목/Day/장소/메모 렌더링(MSW), API 에러 메시지, 에러 시 이동, 탭 기본 선택, 일행 추가 이동, 메모 추가 버튼
  | schedule | 9개 (유닛) | 제목, 버튼 상태, 현재 월 표시, 요일 헤더, 날짜 클릭 → 활성화, 미선택 비활성화, 뒤로가기, 선택 완료 → 이동 + localStorage 저장
  | optimize/route | 8개 (유닛) | 제목, 기본 3일 표시, AM/PM 토글, 출발/도착 라벨, 다음 버튼, localStorage 날짜 로드, 뒤로가기, 다음 → 저장 + 이동
Phase 6 | optimize/places | 9개 (유닛) | 헤더, 검색 입력, GoogleMap → mock div, 기존 장소 로드, 추천경로/추가 버튼, 장소 추가 → sessionStorage, 삭제 → sessionStorage, 로딩 화면
  | optimize/result | 8개 (유닛) | Day 헤더, 장소 로드 → 하단 패널, GoogleMap → mock div, 카테고리 표시, Day 전환(다음/이전), 다음 → check-result 이동, Storage 없으면 미표시
  | optimize/check-result | 10개 (유닛8 + 통합2) | 여행 제목, Day별 장소 분배, Day 섹션 수, 버튼 표시, GoogleMap → mock div, 편집모드 전환, 취소 모달, 모달 확인 → back, 일정 등록 API 성공(MSW 3단계), API 실패 에러 alert



구분 | 수
-- | --
테스트 파일 | 12개
유닛 테스트 | 81개
통합 테스트 | 32개
전체 | 113개


