### PR TITLE
feat:탄스택 쿼리 리팩토링 #115

### DIFF
--- a/frontend/src/app/my-trips/components/TripCard.tsx
+++ b/frontend/src/app/my-trips/components/TripCard.tsx
@@ -4,6 +4,8 @@ import React from 'react'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import styled from 'styled-components'
+import { useQueryClient } from '@tanstack/react-query'
+import { travelQueries } from '@/lib/queries/travelQueries'
 
 interface TripCardProps {
   title: string
@@ -25,9 +27,12 @@ export default function TripCard({
   travelPlanId,
 }: TripCardProps) {
   const router = useRouter()
+  const queryClient = useQueryClient()
 
   const handleClick = () => {
     if (travelPlanId) {
+      // 상세 페이지 진입 전에 해당 여행 정보를 미리 가져와 캐시를 데워 둔다.
+      queryClient.prefetchQuery(travelQueries.plan(travelPlanId))
       router.push(`/mytripdetail?id=${travelPlanId}`)
     } else {
       // fallback: travelPlanId가 없을 경우 (하위 호환성)

--- a/frontend/src/app/optimize/check-result/page.tsx
+++ b/frontend/src/app/optimize/check-result/page.tsx
@@ -8,6 +8,7 @@ import dynamic from 'next/dynamic';
 import RouteMapComponent from '../result/components/RouteMapComponent';
 import { createTravelPlan, createDaySchedule, type TravelPlanRequest, type DayScheduleRequest, type ScheduleRequest } from '@/lib/api/travel';
 import { saveLocations, type LocationSaveRequest } from '@/lib/api/location';
+import { travelQueries } from '@/lib/queries/travelQueries';
 import { useQueryClient } from '@tanstack/react-query';
 
 // TypeScript 인터페이스 정의
@@ -501,7 +502,7 @@ const TravelItineraryApp: React.FC = () => {
         }
 
         // 4. 여행 목록 새로고침
-        queryClient.invalidateQueries({ queryKey: ['travelPlans'] });
+        queryClient.invalidateQueries({ queryKey: travelQueries.plans().queryKey });
 
         // 5. 성공 메시지 및 페이지 이동
         alert('여행 일정이 등록되었습니다!');
@@ -518,7 +519,7 @@ const TravelItineraryApp: React.FC = () => {
         alert(`일정 생성에 실패했습니다.\n\n에러: ${errorMessage}\n\n여행 계획은 생성되었지만 일정이 저장되지 않았습니다. 다시 시도해주세요.`);
         
         // 여행 목록은 새로고침 (부분 성공 상태)
-        queryClient.invalidateQueries({ queryKey: ['travelPlans'] });
+        queryClient.invalidateQueries({ queryKey: travelQueries.plans().queryKey });
         throw scheduleError; // 상위 catch로 전달
       }
     } catch (error: any) {

--- a/frontend/src/lib/hooks/useLocation.ts
+++ b/frontend/src/lib/hooks/useLocation.ts
@@ -1,13 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { 
-  searchPlaces, 
-  saveLocations, 
-  getLocations, 
+import {
+  saveLocations,
   deleteLocation,
   LocationSaveRequest,
-  GooglePlaceResult,
-  LocationResponse
+  LocationResponse,
 } from '../api/location';
+import { locationQueries } from '../queries/locationQueries';
 
 // 장소 검색 훅
 export const useSearchPlaces = (
@@ -17,22 +15,27 @@ export const useSearchPlaces = (
   enabled: boolean = true
 ) => {
   return useQuery({
-    queryKey: ['searchPlaces', query, lat, lng],
-    queryFn: () => searchPlaces(query, lat, lng),
+    ...locationQueries.searchPlaces(query, lat, lng),
     enabled: enabled && query.length > 0,
-    staleTime: 30 * 1000, // 30초
   });
 };
 
 // 장소 저장 훅
-export const useSaveLocations = () => {
+export const useSaveLocations = (travelPlanId: number | null) => {
   const queryClient = useQueryClient();
   
   return useMutation({
     mutationFn: (locations: LocationSaveRequest[]) => saveLocations(locations),
     onSuccess: () => {
-      // 저장 성공 시 캐시 무효화
-      queryClient.invalidateQueries({ queryKey: ['locations'] });
+      // 저장된 여행의 장소 목록만 다시 조회한다.
+      if (!travelPlanId) {
+        queryClient.invalidateQueries({ queryKey: locationQueries.all() });
+        return;
+      }
+
+      queryClient.invalidateQueries({
+        queryKey: locationQueries.locationsByPlan(travelPlanId).queryKey,
+      });
     },
   });
 };
@@ -40,25 +43,59 @@ export const useSaveLocations = () => {
 // 장소 목록 조회 훅
 export const useLocations = (travelPlanId: number | null) => {
   return useQuery({
-    queryKey: ['locations', travelPlanId],
-    queryFn: () => {
-      if (!travelPlanId) throw new Error('Travel plan ID is required');
-      return getLocations(travelPlanId);
-    },
+    ...locationQueries.locationsByPlan(travelPlanId),
     enabled: !!travelPlanId,
-    staleTime: 60 * 1000, // 1분
   });
 };
 
 // 장소 삭제 훅
-export const useDeleteLocation = () => {
+export const useDeleteLocation = (travelPlanId: number | null) => {
   const queryClient = useQueryClient();
   
   return useMutation({
     mutationFn: (locationId: number) => deleteLocation(locationId),
-    onSuccess: () => {
-      // 삭제 성공 시 캐시 무효화
-      queryClient.invalidateQueries({ queryKey: ['locations'] });
+    onMutate: async (locationId: number) => {
+      if (!travelPlanId) {
+        return undefined;
+      }
+
+      const targetQuery = locationQueries.locationsByPlan(travelPlanId);
+
+      await queryClient.cancelQueries({
+        queryKey: targetQuery.queryKey,
+      });
+
+      const previousLocations = queryClient.getQueryData<LocationResponse[]>(
+        targetQuery.queryKey
+      );
+
+      queryClient.setQueryData<LocationResponse[]>(
+        targetQuery.queryKey,
+        (old) => old?.filter((location) => location.locationId !== locationId) ?? old
+      );
+
+      return { previousLocations, targetQuery };
+    },
+    onError: (_error, _locationId, context) => {
+      if (!context?.targetQuery || !context.previousLocations) {
+        return;
+      }
+
+      queryClient.setQueryData(
+        context.targetQuery.queryKey,
+        context.previousLocations
+      );
+    },
+    onSettled: () => {
+      // 낙관적 업데이트 후에도 서버 상태와 최종 동기화를 맞춘다.
+      if (!travelPlanId) {
+        queryClient.invalidateQueries({ queryKey: locationQueries.all() });
+        return;
+      }
+
+      queryClient.invalidateQueries({
+        queryKey: locationQueries.locationsByPlan(travelPlanId).queryKey,
+      });
     },
   });
 };

--- a/frontend/src/lib/hooks/useSearch.ts
+++ b/frontend/src/lib/hooks/useSearch.ts
@@ -1,22 +1,18 @@
-import { useQuery } from '@tanstack/react-query';
-import { searchCountries, searchCities, CountrySearchResponse, CitySearchResponse } from '../api/search';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { searchQueries } from '../queries/searchQueries';
 
 // 국가 검색 훅
 export const useCountries = (keyword?: string) => {
-  return useQuery({
-    queryKey: ['countries', keyword],
-    queryFn: () => searchCountries(keyword),
-    staleTime: 5 * 60 * 1000, // 5분
-  });
+  return useQuery(searchQueries.countries(keyword));
 };
 
 // 도시 검색 훅
 export const useCities = (countryId?: number, keyword?: string) => {
+  // 도시 목록은 "전체 탐색" 화면에서도 사용하므로, 빈 검색어와 countryId 없음도 허용한다.
   return useQuery({
-    queryKey: ['cities', countryId, keyword],
-    queryFn: () => searchCities(countryId, keyword),
+    ...searchQueries.cities(countryId, keyword),
     enabled: true, // 항상 활성화 (countryId와 keyword가 optional이므로)
-    staleTime: 5 * 60 * 1000, // 5분
+    placeholderData: keepPreviousData,
   });
 };
 

--- a/frontend/src/lib/hooks/useTravel.ts
+++ b/frontend/src/lib/hooks/useTravel.ts
@@ -1,33 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
-import { getTravelPlans, getTravelPlan, TravelPlanResponse } from '../api/travel';
+import { travelQueries } from '../queries/travelQueries';
 
 // 여행 일정 목록 조회 훅
 export const useTravelPlans = () => {
-  return useQuery({
-    queryKey: ['travelPlans'],
-    queryFn: () => getTravelPlans(),
-    staleTime: 60 * 1000, // 1분
-    retry: (failureCount, error: any) => {
-      // 401 에러(인증 실패)나 403 에러는 재시도하지 않음
-      if (error?.response?.status === 401 || error?.response?.status === 403) {
-        return false;
-      }
-      // 다른 에러는 최대 1번만 재시도
-      return failureCount < 1;
-    },
-  });
+  return useQuery(travelQueries.plans());
 };
 
 // 여행 일정 단건 조회 훅
 export const useTravelPlan = (travelPlanId: number | null) => {
   return useQuery({
-    queryKey: ['travelPlan', travelPlanId],
-    queryFn: () => {
-      if (!travelPlanId) throw new Error('Travel plan ID is required');
-      return getTravelPlan(travelPlanId);
-    },
+    ...travelQueries.plan(travelPlanId),
     enabled: !!travelPlanId,
-    staleTime: 60 * 1000,
   });
 };
 

--- a/frontend/src/lib/queries/locationQueries.ts
+++ b/frontend/src/lib/queries/locationQueries.ts
@@ -1,0 +1,24 @@
+import { queryOptions } from '@tanstack/react-query';
+import { getLocations, searchPlaces } from '../api/location';
+
+export const locationQueries = {
+  all: () => ['locations'] as const,
+
+  locationsByPlan: (travelPlanId: number | null) =>
+    queryOptions({
+      queryKey: [...locationQueries.all(), travelPlanId] as const,
+      queryFn: () => {
+        if (!travelPlanId) throw new Error('Travel plan ID is required');
+        return getLocations(travelPlanId);
+      },
+      staleTime: 60 * 1000, // 1분
+    }),
+
+  searchPlaces: (query: string, lat?: number, lng?: number) =>
+    queryOptions({
+      queryKey: ['searchPlaces', query, lat, lng] as const,
+      queryFn: () => searchPlaces(query, lat, lng),
+      staleTime: 30 * 1000, // 30초
+    }),
+};
+

--- a/frontend/src/lib/queries/searchQueries.ts
+++ b/frontend/src/lib/queries/searchQueries.ts
@@ -1,0 +1,19 @@
+import { queryOptions } from '@tanstack/react-query';
+import { searchCountries, searchCities } from '../api/search';
+
+export const searchQueries = {
+  countries: (keyword?: string) =>
+    queryOptions({
+      queryKey: ['countries', keyword] as const,
+      queryFn: () => searchCountries(keyword),
+      staleTime: 5 * 60 * 1000, // 5분
+    }),
+
+  cities: (countryId?: number, keyword?: string) =>
+    queryOptions({
+      queryKey: ['cities', countryId, keyword] as const,
+      queryFn: () => searchCities(countryId, keyword),
+      staleTime: 5 * 60 * 1000, // 5분
+    }),
+};
+

--- a/frontend/src/lib/queries/travelQueries.ts
+++ b/frontend/src/lib/queries/travelQueries.ts
@@ -1,0 +1,23 @@
+import { queryOptions } from '@tanstack/react-query';
+import { getTravelPlan, getTravelPlans } from '../api/travel';
+
+export const travelQueries = {
+  all: () => ['travel'] as const,
+
+  plans: () =>
+    queryOptions({
+      queryKey: [...travelQueries.all(), 'plans'] as const,
+      queryFn: getTravelPlans,
+      staleTime: 60 * 1000, // 1분
+    }),
+
+  plan: (travelPlanId: number | null) =>
+    queryOptions({
+      queryKey: [...travelQueries.all(), 'plan', travelPlanId] as const,
+      queryFn: () => {
+        if (!travelPlanId) throw new Error('Travel plan ID is required');
+        return getTravelPlan(travelPlanId);
+      },
+      staleTime: 60 * 1000, // 1분
+    }),
+};

--- a/frontend/src/providers/QueryProvider.tsx
+++ b/frontend/src/providers/QueryProvider.tsx
@@ -12,6 +12,16 @@ export default function QueryProvider({ children }: { children: React.ReactNode 
           queries: {
             staleTime: 60 * 1000, // 1분
             refetchOnWindowFocus: false,
+            // 인증 오류는 재시도해도 의미가 적고, 일시적 오류만 제한적으로 재시도한다.
+            retry: (failureCount, error: any) => {
+              const status = error?.response?.status;
+
+              if (status === 401 || status === 403) {
+                return false;
+              }
+
+              return failureCount < 1;
+            },
           },
         },
       })


### PR DESCRIPTION
 retry 정책 통일
queryKey 팩토리 + queryOptions로 정의를 “원본”에서 재사용
invalidate 범위를 “키 계층”으로 정리
invalidateQueries` vs `setQueryData` 기준 분리
검색 쿼리 정책 정리
placeholderData 도입
상세 진입 체감 속도 개선: prefetchQuery
낙관적 업데이트(rollback 포함)
